### PR TITLE
Game Engine: core rules

### DIFF
--- a/services/ws/game/engine.go
+++ b/services/ws/game/engine.go
@@ -1,0 +1,241 @@
+package game
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"sort"
+)
+
+const PlayerCount = 4
+
+type Suit string
+
+const (
+	Spades   Suit = "spades"
+	Hearts   Suit = "hearts"
+	Diamonds Suit = "diamonds"
+	Clubs    Suit = "clubs"
+)
+
+type Rank int
+
+const (
+	Two   Rank = 2
+	Three Rank = 3
+	Four  Rank = 4
+	Five  Rank = 5
+	Six   Rank = 6
+	Seven Rank = 7
+	Eight Rank = 8
+	Nine  Rank = 9
+	Ten   Rank = 10
+	Jack  Rank = 11
+	Queen Rank = 12
+	King  Rank = 13
+	Ace   Rank = 14
+)
+
+type Card struct {
+	Suit Suit
+	Rank Rank
+}
+
+func (c Card) PointValue() int {
+	return int(c.Rank)
+}
+
+type SuitSequence struct {
+	Low  Rank
+	High Rank
+}
+
+type GameState struct {
+	Hands         [PlayerCount][]Card
+	Board         map[Suit]SuitSequence
+	FaceDown      [PlayerCount][]Card
+	CurrentPlayer int
+}
+
+type MoveOptions struct {
+	Cards        []Card
+	FaceDownOnly bool
+}
+
+var suits = []Suit{Spades, Hearts, Diamonds, Clubs}
+
+func NewGameState() GameState {
+	return GameState{Board: map[Suit]SuitSequence{}}
+}
+
+func Deal(seed int64) (GameState, int) {
+	deck := make([]Card, 0, 52)
+	for _, suit := range suits {
+		for rank := Two; rank <= Ace; rank++ {
+			deck = append(deck, Card{Suit: suit, Rank: rank})
+		}
+	}
+
+	rand.New(rand.NewSource(seed)).Shuffle(len(deck), func(i, j int) {
+		deck[i], deck[j] = deck[j], deck[i]
+	})
+
+	state := NewGameState()
+	starter := -1
+	for index, card := range deck {
+		player := index % PlayerCount
+		state.Hands[player] = append(state.Hands[player], card)
+		if card == (Card{Suit: Spades, Rank: Seven}) {
+			starter = player
+		}
+	}
+	for player := range state.Hands {
+		sortCards(state.Hands[player])
+	}
+	state.CurrentPlayer = starter
+
+	return state, starter
+}
+
+func ValidMoves(state GameState, playerHand []Card) MoveOptions {
+	moves := make([]Card, 0, len(playerHand))
+	for _, card := range playerHand {
+		if isPlayable(state, card) {
+			moves = append(moves, card)
+		}
+	}
+	return MoveOptions{Cards: moves, FaceDownOnly: len(moves) == 0}
+}
+
+func ApplyMove(state GameState, playerIndex int, card Card, faceDown bool) (GameState, error) {
+	if playerIndex < 0 || playerIndex >= PlayerCount {
+		return GameState{}, fmt.Errorf("player index %d out of range", playerIndex)
+	}
+	if !containsCard(state.Hands[playerIndex], card) {
+		return GameState{}, fmt.Errorf("player %d does not hold card %+v", playerIndex, card)
+	}
+
+	moves := ValidMoves(state, state.Hands[playerIndex])
+	if faceDown {
+		if !moves.FaceDownOnly {
+			return GameState{}, errors.New("cannot place face-down while a legal play is available")
+		}
+		updated := cloneState(state)
+		updated.Hands[playerIndex] = removeCard(updated.Hands[playerIndex], card)
+		updated.FaceDown[playerIndex] = append(updated.FaceDown[playerIndex], card)
+		updated.CurrentPlayer = nextPlayerWithCards(updated, playerIndex)
+		return updated, nil
+	}
+
+	if !containsCard(moves.Cards, card) {
+		return GameState{}, fmt.Errorf("card %+v is not playable", card)
+	}
+	updated := cloneState(state)
+	updated.Hands[playerIndex] = removeCard(updated.Hands[playerIndex], card)
+	updated.Board[card.Suit] = applyCardToSequence(updated.Board[card.Suit], card)
+	updated.CurrentPlayer = nextPlayerWithCards(updated, playerIndex)
+	return updated, nil
+}
+
+func IsGameOver(state GameState) bool {
+	for _, hand := range state.Hands {
+		if len(hand) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func CalculateScores(state GameState) [PlayerCount]int {
+	var scores [PlayerCount]int
+	for player, cards := range state.FaceDown {
+		for _, card := range cards {
+			scores[player] += card.PointValue()
+		}
+	}
+	return scores
+}
+
+func isPlayable(state GameState, card Card) bool {
+	sequence, started := state.Board[card.Suit]
+	if !started {
+		if boardIsEmpty(state.Board) {
+			return card == (Card{Suit: Spades, Rank: Seven})
+		}
+		return card.Rank == Seven
+	}
+	return card.Rank == sequence.Low-1 || card.Rank == sequence.High+1
+}
+
+func applyCardToSequence(sequence SuitSequence, card Card) SuitSequence {
+	if sequence == (SuitSequence{}) {
+		return SuitSequence{Low: card.Rank, High: card.Rank}
+	}
+	if card.Rank < sequence.Low {
+		sequence.Low = card.Rank
+	}
+	if card.Rank > sequence.High {
+		sequence.High = card.Rank
+	}
+	return sequence
+}
+
+func boardIsEmpty(board map[Suit]SuitSequence) bool {
+	return len(board) == 0
+}
+
+func nextPlayerWithCards(state GameState, current int) int {
+	if IsGameOver(state) {
+		return current
+	}
+	for offset := 1; offset <= PlayerCount; offset++ {
+		candidate := (current + offset) % PlayerCount
+		if len(state.Hands[candidate]) > 0 {
+			return candidate
+		}
+	}
+	return current
+}
+
+func cloneState(state GameState) GameState {
+	clone := GameState{
+		Board:         make(map[Suit]SuitSequence, len(state.Board)),
+		CurrentPlayer: state.CurrentPlayer,
+	}
+	for player := range state.Hands {
+		clone.Hands[player] = append([]Card(nil), state.Hands[player]...)
+		clone.FaceDown[player] = append([]Card(nil), state.FaceDown[player]...)
+	}
+	for suit, sequence := range state.Board {
+		clone.Board[suit] = sequence
+	}
+	return clone
+}
+
+func containsCard(cards []Card, target Card) bool {
+	for _, card := range cards {
+		if card == target {
+			return true
+		}
+	}
+	return false
+}
+
+func removeCard(cards []Card, target Card) []Card {
+	for index, card := range cards {
+		if card == target {
+			return append(cards[:index], cards[index+1:]...)
+		}
+	}
+	return cards
+}
+
+func sortCards(cards []Card) {
+	suitOrder := map[Suit]int{Spades: 0, Hearts: 1, Diamonds: 2, Clubs: 3}
+	sort.Slice(cards, func(i, j int) bool {
+		if cards[i].Suit != cards[j].Suit {
+			return suitOrder[cards[i].Suit] < suitOrder[cards[j].Suit]
+		}
+		return cards[i].Rank < cards[j].Rank
+	})
+}

--- a/services/ws/game/engine_test.go
+++ b/services/ws/game/engine_test.go
@@ -1,0 +1,218 @@
+package game
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDealIsDeterministicAndFindsSevenSpadeHolder(t *testing.T) {
+	state, starter := Deal(42)
+	repeated, repeatedStarter := Deal(42)
+
+	if starter < 0 || starter >= PlayerCount {
+		t.Fatalf("starter out of range: %d", starter)
+	}
+	if starter != repeatedStarter || !reflect.DeepEqual(state.Hands, repeated.Hands) {
+		t.Fatal("expected deal with same seed to be deterministic")
+	}
+	if state.CurrentPlayer != starter {
+		t.Fatalf("expected current player %d, got %d", starter, state.CurrentPlayer)
+	}
+
+	seen := map[Card]bool{}
+	for player, hand := range state.Hands {
+		if len(hand) != 13 {
+			t.Fatalf("player %d got %d cards, want 13", player, len(hand))
+		}
+		for _, card := range hand {
+			if seen[card] {
+				t.Fatalf("duplicate card dealt: %+v", card)
+			}
+			seen[card] = true
+		}
+	}
+	if len(seen) != 52 {
+		t.Fatalf("expected 52 unique cards, got %d", len(seen))
+	}
+	if !containsCard(state.Hands[starter], Card{Suit: Spades, Rank: Seven}) {
+		t.Fatalf("starter %d does not hold seven of spades", starter)
+	}
+}
+
+func TestCardPointValuesFollowRankValues(t *testing.T) {
+	checks := map[Card]int{
+		{Suit: Clubs, Rank: Two}:     2,
+		{Suit: Hearts, Rank: Ten}:    10,
+		{Suit: Diamonds, Rank: Jack}: 11,
+		{Suit: Spades, Rank: Queen}:  12,
+		{Suit: Clubs, Rank: King}:    13,
+		{Suit: Hearts, Rank: Ace}:    14,
+	}
+
+	for card, want := range checks {
+		if got := card.PointValue(); got != want {
+			t.Fatalf("%+v point value = %d, want %d", card, got, want)
+		}
+	}
+}
+
+func TestValidMovesAtStartRequireSevenOfSpades(t *testing.T) {
+	state := NewGameState()
+	hand := []Card{
+		{Suit: Hearts, Rank: Seven},
+		{Suit: Spades, Rank: Seven},
+		{Suit: Spades, Rank: Six},
+	}
+
+	moves := ValidMoves(state, hand)
+
+	if moves.FaceDownOnly {
+		t.Fatal("expected a playable card")
+	}
+	assertCardsEqual(t, moves.Cards, []Card{{Suit: Spades, Rank: Seven}})
+}
+
+func TestValidMovesAllowSequenceExtensionsAndNewSevenStarts(t *testing.T) {
+	state := NewGameState()
+	state.Board[Spades] = SuitSequence{Low: Six, High: Eight}
+	state.Board[Hearts] = SuitSequence{Low: Seven, High: Seven}
+	hand := []Card{
+		{Suit: Spades, Rank: Five},
+		{Suit: Spades, Rank: Nine},
+		{Suit: Hearts, Rank: Six},
+		{Suit: Diamonds, Rank: Seven},
+		{Suit: Clubs, Rank: Five},
+	}
+
+	moves := ValidMoves(state, hand)
+
+	if moves.FaceDownOnly {
+		t.Fatal("expected playable cards")
+	}
+	assertCardsEqual(t, moves.Cards, []Card{
+		{Suit: Spades, Rank: Five},
+		{Suit: Spades, Rank: Nine},
+		{Suit: Hearts, Rank: Six},
+		{Suit: Diamonds, Rank: Seven},
+	})
+}
+
+func TestValidMovesReportsFaceDownOnlyWhenNoCardIsPlayable(t *testing.T) {
+	state := NewGameState()
+	state.Board[Spades] = SuitSequence{Low: Six, High: Eight}
+	hand := []Card{
+		{Suit: Spades, Rank: Four},
+		{Suit: Hearts, Rank: Nine},
+		{Suit: Clubs, Rank: Three},
+	}
+
+	moves := ValidMoves(state, hand)
+
+	if !moves.FaceDownOnly {
+		t.Fatalf("expected face-down only, got %+v", moves)
+	}
+	if len(moves.Cards) != 0 {
+		t.Fatalf("expected no playable cards, got %+v", moves.Cards)
+	}
+}
+
+func TestApplyMoveUpdatesBoardAndRejectsIllegalMoves(t *testing.T) {
+	state := NewGameState()
+	state.CurrentPlayer = 0
+	state.Hands[0] = []Card{{Suit: Spades, Rank: Seven}, {Suit: Hearts, Rank: Seven}}
+
+	updated, err := ApplyMove(state, 0, Card{Suit: Spades, Rank: Seven}, false)
+	if err != nil {
+		t.Fatalf("apply legal move: %v", err)
+	}
+	if updated.Board[Spades] != (SuitSequence{Low: Seven, High: Seven}) {
+		t.Fatalf("unexpected board: %+v", updated.Board[Spades])
+	}
+	if containsCard(updated.Hands[0], Card{Suit: Spades, Rank: Seven}) {
+		t.Fatal("played card was not removed from hand")
+	}
+
+	if _, err := ApplyMove(updated, 0, Card{Suit: Hearts, Rank: Seven}, true); err == nil {
+		t.Fatal("expected face-down move to be rejected when a valid card is available")
+	}
+	if _, err := ApplyMove(updated, 0, Card{Suit: Clubs, Rank: Nine}, false); err == nil {
+		t.Fatal("expected card not in hand to be rejected")
+	}
+}
+
+func TestApplyMoveAllowsFaceDownOnlyWhenNoValidMoveExistsAndScoresPenalties(t *testing.T) {
+	state := NewGameState()
+	state.Board[Spades] = SuitSequence{Low: Six, High: Eight}
+	state.Hands[2] = []Card{{Suit: Hearts, Rank: Ten}, {Suit: Clubs, Rank: Three}}
+
+	updated, err := ApplyMove(state, 2, Card{Suit: Hearts, Rank: Ten}, true)
+	if err != nil {
+		t.Fatalf("apply face-down move: %v", err)
+	}
+	if len(updated.FaceDown[2]) != 1 || updated.FaceDown[2][0] != (Card{Suit: Hearts, Rank: Ten}) {
+		t.Fatalf("unexpected face-down cards: %+v", updated.FaceDown[2])
+	}
+	if containsCard(updated.Hands[2], Card{Suit: Hearts, Rank: Ten}) {
+		t.Fatal("face-down card was not removed from hand")
+	}
+
+	scores := CalculateScores(updated)
+	if scores[2] != 10 {
+		t.Fatalf("expected player 2 score 10, got %d", scores[2])
+	}
+}
+
+func TestFullGameSimulationReachesGameOver(t *testing.T) {
+	state, _ := Deal(7)
+	turns := 0
+
+	for !IsGameOver(state) {
+		if turns > 300 {
+			t.Fatal("simulation did not finish")
+		}
+
+		player := state.CurrentPlayer
+		moves := ValidMoves(state, state.Hands[player])
+		card := state.Hands[player][0]
+		faceDown := true
+		if !moves.FaceDownOnly {
+			card = moves.Cards[0]
+			faceDown = false
+		}
+
+		var err error
+		state, err = ApplyMove(state, player, card, faceDown)
+		if err != nil {
+			t.Fatalf("turn %d player %d applying %+v faceDown=%t: %v", turns, player, card, faceDown, err)
+		}
+		turns++
+	}
+
+	if !IsGameOver(state) {
+		t.Fatal("expected game over")
+	}
+	for player, hand := range state.Hands {
+		if len(hand) != 0 {
+			t.Fatalf("player %d still has cards: %+v", player, hand)
+		}
+	}
+}
+
+func TestIsGameOverRequiresAllHandsToBeEmpty(t *testing.T) {
+	state := NewGameState()
+	if !IsGameOver(state) {
+		t.Fatal("expected empty hands to be game over")
+	}
+
+	state.Hands[3] = []Card{{Suit: Diamonds, Rank: Two}}
+	if IsGameOver(state) {
+		t.Fatal("expected game to continue while any player has cards")
+	}
+}
+
+func assertCardsEqual(t *testing.T, got, want []Card) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cards mismatch\ngot:  %+v\nwant: %+v", got, want)
+	}
+}


### PR DESCRIPTION
Closes #3

## Summary
Implemented a pure Go Seven Spade game engine package for deterministic dealing, legal move generation, move application, game-over detection, and penalty scoring.

## Changes
- Added card, rank, suit, game state, board sequence, and move option types in services/ws/game.
- Added deterministic Deal(seed), ValidMoves, ApplyMove, IsGameOver, and CalculateScores.
- Added unit coverage for start/mid-game moves, face-down-only moves, illegal face-down rejection, deterministic deals, full simulation, and scoring.

## Decisions
- Kept Ace closing consistency out of this slice because roadmap issue #4 owns that rule.
- Used a pure package with no I/O dependencies so the WebSocket service can consume it later.