### PR TITLE
OAuth: Google + GitHub

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -97,11 +97,19 @@ Exchanges a valid refresh token for a new JWT.
 
 #### `GET /auth/google`
 
-Redirects to Google OAuth consent. On callback, upserts the user in PostgreSQL and returns a JWT.
+Redirects to Google OAuth consent. The handler sets a short-lived `oauth_state_google` cookie (10 minutes, HttpOnly, SameSite=Lax) used to validate the callback. Requires `GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET`, and `GOOGLE_OAUTH_REDIRECT_URL` to be configured; otherwise returns `503`.
+
+#### `GET /auth/google/callback`
+
+Exchanges the authorization code for a Google access token, fetches the user's profile, and upserts the user in PostgreSQL (matched first by `(provider, provider_user_id)`, then by `email`). On success, the browser is redirected to `${FRONTEND_URL}/auth/callback#provider=google&jwt=<jwt>&refresh_token=<refresh>`. On failure, the redirect contains `error=<code>` and no tokens.
 
 #### `GET /auth/github`
 
-Redirects to GitHub OAuth consent. On callback, upserts the user and returns a JWT.
+Same flow as `/auth/google` but for GitHub. Requires `GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET`, and `GITHUB_OAUTH_REDIRECT_URL`. Sets an `oauth_state_github` cookie.
+
+#### `GET /auth/github/callback`
+
+Exchanges the code, fetches `/user` and (if needed) `/user/emails` to find the primary verified email, then upserts the user and redirects the SPA as above.
 
 #### `POST /auth/telegram`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,7 +141,6 @@
       "integrity": "sha512-WDlRiWRSWlmhCPq09bvAofK0qr5vM4yNklXjoJdZHmugKRRTpN/Okn3ODnjgM/Kb/4hjMrRyrsUeH/Brieq7KA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "find-my-way-ts": "^0.1.6",
         "msgpackr": "^1.11.4",
@@ -196,7 +195,6 @@
       "integrity": "sha512-f/+QVyqACuLkoB+HDDX2XxloslmgMDL+C6ecHBV0cB0zJzJmLCOybwOkRcCI2xJ/DWHEIpoRyvq+Bfdza0AIrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@effect/typeclass": "^0.39.0",
         "effect": "^3.20.0"
@@ -208,7 +206,6 @@
       "integrity": "sha512-CzQ5kiomjR9DZ6LPfKAaWmys6JU65c2Q/VQcTKRK4RfaDWeTAehpAVmgOIyKSPkcr9XBhjo2cJx4xyZ4E5nN7g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@effect/printer": "^0.48.0"
       },
@@ -1154,7 +1151,6 @@
       "integrity": "sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "fast-check": "^3.23.1"
@@ -1325,7 +1321,8 @@
       "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
       "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/mime": {
       "version": "3.0.0",
@@ -1504,6 +1501,7 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }

--- a/services/api/main.go
+++ b/services/api/main.go
@@ -91,6 +91,8 @@ func main() {
 	mux.HandleFunc("POST /login", loginHandler(db, jwtSecret))
 	mux.HandleFunc("POST /refresh", refreshHandler(db, jwtSecret))
 
+	registerOAuthRoutes(mux, db, jwtSecret)
+
 	log.Printf("API service listening on :%s", port)
 	if err := http.ListenAndServe(":"+port, withCORS(mux)); err != nil {
 		log.Fatal(err)
@@ -299,8 +301,8 @@ func loginHandler(db *sql.DB, jwtSecret string) http.HandlerFunc {
 			return
 		}
 
-		// Check if user exists and password matches
-		if user == nil || ComparePassword(user.PasswordHash, req.Password) != nil {
+		// Check if user exists, has a password set, and password matches
+		if user == nil || !user.PasswordHash.Valid || ComparePassword(user.PasswordHash.String, req.Password) != nil {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)
 			_ = json.NewEncoder(w).Encode(errorResponse{Error: "Invalid email or password"})
@@ -438,4 +440,43 @@ func withCORS(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// registerOAuthRoutes wires the Google and GitHub OAuth start/callback routes onto the given mux.
+// Providers without a configured client ID are still registered so the frontend can detect
+// unconfigured providers (the start handler returns 503).
+func registerOAuthRoutes(mux *http.ServeMux, db *sql.DB, jwtSecret string) {
+	stateSecret := os.Getenv("OAUTH_STATE_SECRET")
+	if stateSecret == "" {
+		stateSecret = jwtSecret
+	}
+	frontendURL := os.Getenv("FRONTEND_URL")
+	if frontendURL == "" {
+		frontendURL = "http://localhost:5173"
+	}
+
+	deps := OAuthDeps{
+		DB:          db,
+		JWTSecret:   jwtSecret,
+		StateSecret: stateSecret,
+		FrontendURL: frontendURL,
+	}
+
+	googleCfg := googleProvider(
+		os.Getenv("GOOGLE_OAUTH_CLIENT_ID"),
+		os.Getenv("GOOGLE_OAUTH_CLIENT_SECRET"),
+		os.Getenv("GOOGLE_OAUTH_REDIRECT_URL"),
+		nil,
+	)
+	mux.HandleFunc("GET /auth/google", oauthStartHandler(googleCfg, deps))
+	mux.HandleFunc("GET /auth/google/callback", oauthCallbackHandler(googleCfg, deps))
+
+	githubCfg := githubProvider(
+		os.Getenv("GITHUB_OAUTH_CLIENT_ID"),
+		os.Getenv("GITHUB_OAUTH_CLIENT_SECRET"),
+		os.Getenv("GITHUB_OAUTH_REDIRECT_URL"),
+		nil,
+	)
+	mux.HandleFunc("GET /auth/github", oauthStartHandler(githubCfg, deps))
+	mux.HandleFunc("GET /auth/github/callback", oauthCallbackHandler(githubCfg, deps))
 }

--- a/services/api/migrations/002_oauth_users.sql
+++ b/services/api/migrations/002_oauth_users.sql
@@ -1,0 +1,12 @@
+-- Allow password_hash to be NULL for OAuth-only users
+ALTER TABLE users ALTER COLUMN password_hash DROP NOT NULL;
+
+-- Add OAuth provider fields
+ALTER TABLE users ADD COLUMN IF NOT EXISTS provider VARCHAR(32);
+ALTER TABLE users ADD COLUMN IF NOT EXISTS provider_user_id VARCHAR(255);
+ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar_url TEXT;
+
+-- Allow looking up by provider+provider_user_id and ensure each provider account maps to one user.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_provider_provider_user_id
+    ON users(provider, provider_user_id)
+    WHERE provider IS NOT NULL AND provider_user_id IS NOT NULL;

--- a/services/api/models.go
+++ b/services/api/models.go
@@ -9,11 +9,14 @@ import (
 )
 
 type User struct {
-	ID           uuid.UUID
-	Email        string
-	PasswordHash string
-	DisplayName  string
-	CreatedAt    time.Time
+	ID             uuid.UUID
+	Email          string
+	PasswordHash   sql.NullString
+	DisplayName    string
+	Provider       sql.NullString
+	ProviderUserID sql.NullString
+	AvatarURL      sql.NullString
+	CreatedAt      time.Time
 }
 
 type RefreshToken struct {
@@ -24,12 +27,12 @@ type RefreshToken struct {
 	CreatedAt time.Time
 }
 
-// CreateUser inserts a new user into the database
+// CreateUser inserts a new user into the database (email/password registration)
 func CreateUser(db *sql.DB, email, passwordHash, displayName string) (*User, error) {
 	user := &User{
 		ID:           uuid.New(),
 		Email:        email,
-		PasswordHash: passwordHash,
+		PasswordHash: sql.NullString{String: passwordHash, Valid: true},
 		DisplayName:  displayName,
 		CreatedAt:    time.Now(),
 	}
@@ -37,11 +40,11 @@ func CreateUser(db *sql.DB, email, passwordHash, displayName string) (*User, err
 	query := `
 		INSERT INTO users (id, email, password_hash, display_name, created_at)
 		VALUES ($1, $2, $3, $4, $5)
-		RETURNING id, email, password_hash, display_name, created_at
+		RETURNING id, email, password_hash, display_name, provider, provider_user_id, avatar_url, created_at
 	`
 
 	err := db.QueryRow(query, user.ID, user.Email, user.PasswordHash, user.DisplayName, user.CreatedAt).
-		Scan(&user.ID, &user.Email, &user.PasswordHash, &user.DisplayName, &user.CreatedAt)
+		Scan(&user.ID, &user.Email, &user.PasswordHash, &user.DisplayName, &user.Provider, &user.ProviderUserID, &user.AvatarURL, &user.CreatedAt)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create user: %w", err)
@@ -54,13 +57,13 @@ func CreateUser(db *sql.DB, email, passwordHash, displayName string) (*User, err
 func GetUserByEmail(db *sql.DB, email string) (*User, error) {
 	user := &User{}
 	query := `
-		SELECT id, email, password_hash, display_name, created_at
+		SELECT id, email, password_hash, display_name, provider, provider_user_id, avatar_url, created_at
 		FROM users
 		WHERE email = $1
 	`
 
 	err := db.QueryRow(query, email).
-		Scan(&user.ID, &user.Email, &user.PasswordHash, &user.DisplayName, &user.CreatedAt)
+		Scan(&user.ID, &user.Email, &user.PasswordHash, &user.DisplayName, &user.Provider, &user.ProviderUserID, &user.AvatarURL, &user.CreatedAt)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -76,13 +79,13 @@ func GetUserByEmail(db *sql.DB, email string) (*User, error) {
 func GetUserByID(db *sql.DB, id uuid.UUID) (*User, error) {
 	user := &User{}
 	query := `
-		SELECT id, email, password_hash, display_name, created_at
+		SELECT id, email, password_hash, display_name, provider, provider_user_id, avatar_url, created_at
 		FROM users
 		WHERE id = $1
 	`
 
 	err := db.QueryRow(query, id).
-		Scan(&user.ID, &user.Email, &user.PasswordHash, &user.DisplayName, &user.CreatedAt)
+		Scan(&user.ID, &user.Email, &user.PasswordHash, &user.DisplayName, &user.Provider, &user.ProviderUserID, &user.AvatarURL, &user.CreatedAt)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -91,6 +94,109 @@ func GetUserByID(db *sql.DB, id uuid.UUID) (*User, error) {
 		return nil, fmt.Errorf("failed to get user by ID: %w", err)
 	}
 
+	return user, nil
+}
+
+// GetUserByProvider returns the user matching (provider, provider_user_id), or nil if not found.
+func GetUserByProvider(db *sql.DB, provider, providerUserID string) (*User, error) {
+	user := &User{}
+	query := `
+		SELECT id, email, password_hash, display_name, provider, provider_user_id, avatar_url, created_at
+		FROM users
+		WHERE provider = $1 AND provider_user_id = $2
+	`
+
+	err := db.QueryRow(query, provider, providerUserID).
+		Scan(&user.ID, &user.Email, &user.PasswordHash, &user.DisplayName, &user.Provider, &user.ProviderUserID, &user.AvatarURL, &user.CreatedAt)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user by provider: %w", err)
+	}
+
+	return user, nil
+}
+
+// OAuthProfile holds the normalised user profile information returned by an OAuth provider.
+type OAuthProfile struct {
+	Provider       string
+	ProviderUserID string
+	Email          string
+	DisplayName    string
+	AvatarURL      string
+}
+
+// UpsertOAuthUser creates a user for the given OAuth profile, or updates an existing matching
+// user (matched first by provider+provider_user_id, then by email). Returns the persisted user.
+func UpsertOAuthUser(db *sql.DB, profile OAuthProfile) (*User, error) {
+	if profile.Provider == "" || profile.ProviderUserID == "" {
+		return nil, fmt.Errorf("provider and provider_user_id are required")
+	}
+	if profile.Email == "" {
+		return nil, fmt.Errorf("email is required")
+	}
+	if profile.DisplayName == "" {
+		profile.DisplayName = profile.Email
+	}
+
+	// Match by provider identity first
+	existing, err := GetUserByProvider(db, profile.Provider, profile.ProviderUserID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fall back to email (e.g. user previously registered with email/password)
+	if existing == nil {
+		existing, err = GetUserByEmail(db, profile.Email)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	avatar := sql.NullString{String: profile.AvatarURL, Valid: profile.AvatarURL != ""}
+
+	if existing != nil {
+		// Update display name, avatar, and link the provider identity if missing
+		query := `
+			UPDATE users
+			SET display_name = $1,
+			    avatar_url = $2,
+			    provider = $3,
+			    provider_user_id = $4
+			WHERE id = $5
+			RETURNING id, email, password_hash, display_name, provider, provider_user_id, avatar_url, created_at
+		`
+		updated := &User{}
+		err := db.QueryRow(query, profile.DisplayName, avatar, profile.Provider, profile.ProviderUserID, existing.ID).
+			Scan(&updated.ID, &updated.Email, &updated.PasswordHash, &updated.DisplayName, &updated.Provider, &updated.ProviderUserID, &updated.AvatarURL, &updated.CreatedAt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update oauth user: %w", err)
+		}
+		return updated, nil
+	}
+
+	// Create new OAuth user (no password)
+	user := &User{
+		ID:             uuid.New(),
+		Email:          profile.Email,
+		DisplayName:    profile.DisplayName,
+		Provider:       sql.NullString{String: profile.Provider, Valid: true},
+		ProviderUserID: sql.NullString{String: profile.ProviderUserID, Valid: true},
+		AvatarURL:      avatar,
+		CreatedAt:      time.Now(),
+	}
+	insert := `
+		INSERT INTO users (id, email, display_name, provider, provider_user_id, avatar_url, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		RETURNING id, email, password_hash, display_name, provider, provider_user_id, avatar_url, created_at
+	`
+	err = db.QueryRow(insert, user.ID, user.Email, user.DisplayName, user.Provider, user.ProviderUserID, user.AvatarURL, user.CreatedAt).
+		Scan(&user.ID, &user.Email, &user.PasswordHash, &user.DisplayName, &user.Provider, &user.ProviderUserID, &user.AvatarURL, &user.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to insert oauth user: %w", err)
+	}
 	return user, nil
 }
 

--- a/services/api/oauth.go
+++ b/services/api/oauth.go
@@ -1,0 +1,463 @@
+package main
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// OAuthProviderConfig describes a single OAuth2 provider (Google or GitHub).
+type OAuthProviderConfig struct {
+	Name         string
+	ClientID     string
+	ClientSecret string
+	RedirectURL  string
+	AuthURL      string
+	TokenURL     string
+	Scopes       []string
+	// FetchUser exchanges an access token for a normalised OAuthProfile.
+	// The Provider field of the returned profile is populated by the handler.
+	FetchUser func(ctx context.Context, accessToken string) (OAuthProfile, error)
+}
+
+// OAuthDeps bundles the dependencies the OAuth handlers need.
+type OAuthDeps struct {
+	DB                *sql.DB
+	JWTSecret         string
+	StateSecret       string
+	FrontendURL       string
+	HTTPClient        *http.Client
+	Now               func() time.Time
+	ExchangeCodeToken func(ctx context.Context, cfg OAuthProviderConfig, code string) (string, error)
+}
+
+const (
+	oauthStateCookie = "oauth_state"
+	oauthStateMaxAge = 10 * 60 // 10 minutes
+)
+
+// generateRandomState returns a URL-safe random state string.
+func generateRandomState() (string, error) {
+	b := make([]byte, 24)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// signState produces a deterministic HMAC of the state value using the configured secret.
+func signState(state, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(state))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// oauthStartHandler redirects the user to the provider's consent screen.
+func oauthStartHandler(cfg OAuthProviderConfig, deps OAuthDeps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if cfg.ClientID == "" || cfg.RedirectURL == "" {
+			http.Error(w, fmt.Sprintf("%s OAuth is not configured", cfg.Name), http.StatusServiceUnavailable)
+			return
+		}
+
+		state, err := generateRandomState()
+		if err != nil {
+			log.Printf("oauth: failed to generate state: %v", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+
+		signedState := state + "." + signState(state, deps.StateSecret)
+
+		http.SetCookie(w, &http.Cookie{
+			Name:     oauthStateCookie + "_" + cfg.Name,
+			Value:    signedState,
+			Path:     "/",
+			MaxAge:   oauthStateMaxAge,
+			HttpOnly: true,
+			Secure:   r.TLS != nil,
+			SameSite: http.SameSiteLaxMode,
+		})
+
+		params := url.Values{}
+		params.Set("client_id", cfg.ClientID)
+		params.Set("redirect_uri", cfg.RedirectURL)
+		params.Set("response_type", "code")
+		params.Set("state", signedState)
+		if len(cfg.Scopes) > 0 {
+			params.Set("scope", strings.Join(cfg.Scopes, " "))
+		}
+
+		http.Redirect(w, r, cfg.AuthURL+"?"+params.Encode(), http.StatusFound)
+	}
+}
+
+// oauthCallbackHandler validates state, exchanges the code for tokens, fetches the user
+// profile, upserts the user, and redirects the SPA to the configured frontend URL with
+// the JWT and refresh token in the URL fragment.
+func oauthCallbackHandler(cfg OAuthProviderConfig, deps OAuthDeps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+		if errParam := query.Get("error"); errParam != "" {
+			redirectFrontend(w, r, deps.FrontendURL, cfg.Name, "", "", errParam)
+			return
+		}
+
+		state := query.Get("state")
+		code := query.Get("code")
+		if state == "" || code == "" {
+			redirectFrontend(w, r, deps.FrontendURL, cfg.Name, "", "", "missing_state_or_code")
+			return
+		}
+
+		cookie, err := r.Cookie(oauthStateCookie + "_" + cfg.Name)
+		if err != nil || cookie.Value == "" {
+			redirectFrontend(w, r, deps.FrontendURL, cfg.Name, "", "", "missing_state_cookie")
+			return
+		}
+		if cookie.Value != state {
+			redirectFrontend(w, r, deps.FrontendURL, cfg.Name, "", "", "state_mismatch")
+			return
+		}
+		parts := strings.SplitN(state, ".", 2)
+		if len(parts) != 2 || !hmac.Equal([]byte(parts[1]), []byte(signState(parts[0], deps.StateSecret))) {
+			redirectFrontend(w, r, deps.FrontendURL, cfg.Name, "", "", "state_invalid")
+			return
+		}
+
+		// Clear the state cookie now that it has been used.
+		http.SetCookie(w, &http.Cookie{
+			Name:     oauthStateCookie + "_" + cfg.Name,
+			Value:    "",
+			Path:     "/",
+			MaxAge:   -1,
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+		})
+
+		exchange := deps.ExchangeCodeToken
+		if exchange == nil {
+			exchange = defaultExchangeCodeToken(deps.HTTPClient)
+		}
+
+		ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+		defer cancel()
+
+		accessToken, err := exchange(ctx, cfg, code)
+		if err != nil {
+			log.Printf("oauth %s: token exchange failed: %v", cfg.Name, err)
+			redirectFrontend(w, r, deps.FrontendURL, cfg.Name, "", "", "token_exchange_failed")
+			return
+		}
+
+		profile, err := cfg.FetchUser(ctx, accessToken)
+		if err != nil {
+			log.Printf("oauth %s: profile fetch failed: %v", cfg.Name, err)
+			redirectFrontend(w, r, deps.FrontendURL, cfg.Name, "", "", "profile_fetch_failed")
+			return
+		}
+		profile.Provider = cfg.Name
+
+		if profile.Email == "" {
+			redirectFrontend(w, r, deps.FrontendURL, cfg.Name, "", "", "no_email")
+			return
+		}
+
+		user, err := UpsertOAuthUser(deps.DB, profile)
+		if err != nil {
+			log.Printf("oauth %s: upsert failed: %v", cfg.Name, err)
+			redirectFrontend(w, r, deps.FrontendURL, cfg.Name, "", "", "upsert_failed")
+			return
+		}
+
+		jwtToken, err := GenerateUserToken(user.ID.String(), user.DisplayName, deps.JWTSecret)
+		if err != nil {
+			log.Printf("oauth %s: jwt failed: %v", cfg.Name, err)
+			redirectFrontend(w, r, deps.FrontendURL, cfg.Name, "", "", "jwt_failed")
+			return
+		}
+
+		refreshToken, err := GenerateRefreshToken()
+		if err != nil {
+			log.Printf("oauth %s: refresh token failed: %v", cfg.Name, err)
+			redirectFrontend(w, r, deps.FrontendURL, cfg.Name, "", "", "refresh_failed")
+			return
+		}
+		now := time.Now
+		if deps.Now != nil {
+			now = deps.Now
+		}
+		if err := StoreRefreshToken(deps.DB, user.ID, HashRefreshToken(refreshToken), now().Add(30*24*time.Hour)); err != nil {
+			log.Printf("oauth %s: store refresh token failed: %v", cfg.Name, err)
+			redirectFrontend(w, r, deps.FrontendURL, cfg.Name, "", "", "store_refresh_failed")
+			return
+		}
+
+		redirectFrontend(w, r, deps.FrontendURL, cfg.Name, jwtToken, refreshToken, "")
+	}
+}
+
+// redirectFrontend sends the browser back to the SPA with the auth result encoded in the URL fragment.
+// Tokens go in the fragment so that they don't appear in server logs or referrers.
+func redirectFrontend(w http.ResponseWriter, r *http.Request, frontendURL, provider, jwtToken, refreshToken, errorCode string) {
+	target := frontendURL
+	if target == "" {
+		target = "/"
+	}
+	if !strings.Contains(target, "/auth/callback") {
+		target = strings.TrimRight(target, "/") + "/auth/callback"
+	}
+
+	frag := url.Values{}
+	frag.Set("provider", provider)
+	if jwtToken != "" {
+		frag.Set("jwt", jwtToken)
+	}
+	if refreshToken != "" {
+		frag.Set("refresh_token", refreshToken)
+	}
+	if errorCode != "" {
+		frag.Set("error", errorCode)
+	}
+
+	http.Redirect(w, r, target+"#"+frag.Encode(), http.StatusFound)
+}
+
+// defaultExchangeCodeToken performs the standard OAuth2 authorization-code -> access token
+// exchange via POST application/x-www-form-urlencoded.
+func defaultExchangeCodeToken(client *http.Client) func(ctx context.Context, cfg OAuthProviderConfig, code string) (string, error) {
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	return func(ctx context.Context, cfg OAuthProviderConfig, code string) (string, error) {
+		form := url.Values{}
+		form.Set("client_id", cfg.ClientID)
+		form.Set("client_secret", cfg.ClientSecret)
+		form.Set("code", code)
+		form.Set("grant_type", "authorization_code")
+		form.Set("redirect_uri", cfg.RedirectURL)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.TokenURL, strings.NewReader(form.Encode()))
+		if err != nil {
+			return "", err
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Accept", "application/json")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return "", fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, string(body))
+		}
+
+		var parsed struct {
+			AccessToken string `json:"access_token"`
+			Error       string `json:"error"`
+		}
+		if err := json.Unmarshal(body, &parsed); err != nil {
+			// GitHub may return application/x-www-form-urlencoded by default; parse that too.
+			if values, qerr := url.ParseQuery(string(body)); qerr == nil {
+				if tok := values.Get("access_token"); tok != "" {
+					return tok, nil
+				}
+				if e := values.Get("error"); e != "" {
+					return "", fmt.Errorf("token endpoint error: %s", e)
+				}
+			}
+			return "", fmt.Errorf("invalid token response: %w", err)
+		}
+		if parsed.Error != "" {
+			return "", fmt.Errorf("token endpoint error: %s", parsed.Error)
+		}
+		if parsed.AccessToken == "" {
+			return "", errors.New("token endpoint returned empty access_token")
+		}
+		return parsed.AccessToken, nil
+	}
+}
+
+// googleProvider builds an OAuthProviderConfig for Google with sensible defaults.
+func googleProvider(clientID, clientSecret, redirectURL string, httpClient *http.Client) OAuthProviderConfig {
+	return OAuthProviderConfig{
+		Name:         "google",
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  redirectURL,
+		AuthURL:      "https://accounts.google.com/o/oauth2/v2/auth",
+		TokenURL:     "https://oauth2.googleapis.com/token",
+		Scopes:       []string{"openid", "email", "profile"},
+		FetchUser:    fetchGoogleProfile(httpClient),
+	}
+}
+
+// githubProvider builds an OAuthProviderConfig for GitHub with sensible defaults.
+func githubProvider(clientID, clientSecret, redirectURL string, httpClient *http.Client) OAuthProviderConfig {
+	return OAuthProviderConfig{
+		Name:         "github",
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  redirectURL,
+		AuthURL:      "https://github.com/login/oauth/authorize",
+		TokenURL:     "https://github.com/login/oauth/access_token",
+		Scopes:       []string{"read:user", "user:email"},
+		FetchUser:    fetchGithubProfile(httpClient),
+	}
+}
+
+func httpClientOrDefault(c *http.Client) *http.Client {
+	if c != nil {
+		return c
+	}
+	return &http.Client{Timeout: 10 * time.Second}
+}
+
+// fetchGoogleProfile retrieves the user's profile from Google's userinfo endpoint.
+func fetchGoogleProfile(client *http.Client) func(ctx context.Context, accessToken string) (OAuthProfile, error) {
+	c := httpClientOrDefault(client)
+	return func(ctx context.Context, accessToken string) (OAuthProfile, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://openidconnect.googleapis.com/v1/userinfo", nil)
+		if err != nil {
+			return OAuthProfile{}, err
+		}
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		req.Header.Set("Accept", "application/json")
+		resp, err := c.Do(req)
+		if err != nil {
+			return OAuthProfile{}, err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			body, _ := io.ReadAll(resp.Body)
+			return OAuthProfile{}, fmt.Errorf("google userinfo returned %d: %s", resp.StatusCode, string(body))
+		}
+		var data struct {
+			Sub     string `json:"sub"`
+			Email   string `json:"email"`
+			Name    string `json:"name"`
+			Picture string `json:"picture"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			return OAuthProfile{}, err
+		}
+		if data.Sub == "" {
+			return OAuthProfile{}, errors.New("google userinfo missing sub")
+		}
+		display := data.Name
+		if display == "" {
+			display = data.Email
+		}
+		return OAuthProfile{
+			ProviderUserID: data.Sub,
+			Email:          strings.ToLower(data.Email),
+			DisplayName:    display,
+			AvatarURL:      data.Picture,
+		}, nil
+	}
+}
+
+// fetchGithubProfile retrieves the user's profile (including a primary verified email) from GitHub.
+func fetchGithubProfile(client *http.Client) func(ctx context.Context, accessToken string) (OAuthProfile, error) {
+	c := httpClientOrDefault(client)
+	return func(ctx context.Context, accessToken string) (OAuthProfile, error) {
+		// /user
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/user", nil)
+		if err != nil {
+			return OAuthProfile{}, err
+		}
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		req.Header.Set("Accept", "application/vnd.github+json")
+		resp, err := c.Do(req)
+		if err != nil {
+			return OAuthProfile{}, err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			body, _ := io.ReadAll(resp.Body)
+			return OAuthProfile{}, fmt.Errorf("github /user returned %d: %s", resp.StatusCode, string(body))
+		}
+		var user struct {
+			ID        int64  `json:"id"`
+			Login     string `json:"login"`
+			Name      string `json:"name"`
+			Email     string `json:"email"`
+			AvatarURL string `json:"avatar_url"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
+			return OAuthProfile{}, err
+		}
+		if user.ID == 0 {
+			return OAuthProfile{}, errors.New("github /user missing id")
+		}
+
+		email := user.Email
+		if email == "" {
+			// Fetch the user's primary verified email
+			req2, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/user/emails", nil)
+			if err != nil {
+				return OAuthProfile{}, err
+			}
+			req2.Header.Set("Authorization", "Bearer "+accessToken)
+			req2.Header.Set("Accept", "application/vnd.github+json")
+			emailResp, err := c.Do(req2)
+			if err != nil {
+				return OAuthProfile{}, err
+			}
+			defer emailResp.Body.Close()
+			if emailResp.StatusCode >= 200 && emailResp.StatusCode < 300 {
+				var emails []struct {
+					Email    string `json:"email"`
+					Primary  bool   `json:"primary"`
+					Verified bool   `json:"verified"`
+				}
+				if err := json.NewDecoder(emailResp.Body).Decode(&emails); err == nil {
+					for _, e := range emails {
+						if e.Primary && e.Verified {
+							email = e.Email
+							break
+						}
+					}
+					if email == "" {
+						for _, e := range emails {
+							if e.Verified {
+								email = e.Email
+								break
+							}
+						}
+					}
+				}
+			}
+		}
+
+		display := user.Name
+		if display == "" {
+			display = user.Login
+		}
+		return OAuthProfile{
+			ProviderUserID: fmt.Sprintf("%d", user.ID),
+			Email:          strings.ToLower(email),
+			DisplayName:    display,
+			AvatarURL:      user.AvatarURL,
+		}, nil
+	}
+}

--- a/services/api/oauth_test.go
+++ b/services/api/oauth_test.go
@@ -1,0 +1,319 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// fakeOAuthFetchUser returns a static profile for tests.
+func fakeOAuthFetchUser(profile OAuthProfile) func(ctx context.Context, accessToken string) (OAuthProfile, error) {
+	return func(ctx context.Context, accessToken string) (OAuthProfile, error) {
+		return profile, nil
+	}
+}
+
+func newTestOAuthConfig(name string, fetch func(ctx context.Context, accessToken string) (OAuthProfile, error)) OAuthProviderConfig {
+	return OAuthProviderConfig{
+		Name:         name,
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		RedirectURL:  "http://localhost:8080/auth/" + name + "/callback",
+		AuthURL:      "https://provider.example.com/authorize",
+		TokenURL:     "https://provider.example.com/token",
+		Scopes:       []string{"email", "profile"},
+		FetchUser:    fetch,
+	}
+}
+
+func TestOAuthStartRedirectsToProviderWithStateCookie(t *testing.T) {
+	cfg := newTestOAuthConfig("google", fakeOAuthFetchUser(OAuthProfile{}))
+	deps := OAuthDeps{StateSecret: "state-secret"}
+
+	handler := oauthStartHandler(cfg, deps)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/auth/google", nil)
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusFound {
+		t.Fatalf("expected 302, got %d", rr.Code)
+	}
+
+	loc := rr.Header().Get("Location")
+	if !strings.HasPrefix(loc, cfg.AuthURL+"?") {
+		t.Fatalf("expected redirect to provider, got %q", loc)
+	}
+
+	parsed, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("parse redirect: %v", err)
+	}
+	q := parsed.Query()
+	if q.Get("client_id") != cfg.ClientID {
+		t.Errorf("expected client_id=%q, got %q", cfg.ClientID, q.Get("client_id"))
+	}
+	if q.Get("redirect_uri") != cfg.RedirectURL {
+		t.Errorf("expected redirect_uri=%q, got %q", cfg.RedirectURL, q.Get("redirect_uri"))
+	}
+	if q.Get("response_type") != "code" {
+		t.Errorf("expected response_type=code, got %q", q.Get("response_type"))
+	}
+	if q.Get("state") == "" {
+		t.Error("expected state to be set")
+	}
+
+	// Verify a state cookie was set.
+	cookies := rr.Result().Cookies()
+	var stateCookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == oauthStateCookie+"_google" {
+			stateCookie = c
+		}
+	}
+	if stateCookie == nil {
+		t.Fatal("expected oauth_state_google cookie")
+	}
+	if stateCookie.Value != q.Get("state") {
+		t.Errorf("cookie value %q doesn't match state %q", stateCookie.Value, q.Get("state"))
+	}
+}
+
+func TestOAuthStartReturnsServiceUnavailableIfNotConfigured(t *testing.T) {
+	cfg := OAuthProviderConfig{Name: "google"} // missing ClientID/RedirectURL
+	deps := OAuthDeps{StateSecret: "state-secret"}
+
+	handler := oauthStartHandler(cfg, deps)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/auth/google", nil)
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rr.Code)
+	}
+}
+
+func TestOAuthCallbackRejectsMissingState(t *testing.T) {
+	cfg := newTestOAuthConfig("github", fakeOAuthFetchUser(OAuthProfile{}))
+	deps := OAuthDeps{StateSecret: "state-secret", FrontendURL: "http://localhost:5173"}
+
+	handler := oauthCallbackHandler(cfg, deps)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/auth/github/callback?code=abc", nil)
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusFound {
+		t.Fatalf("expected 302, got %d", rr.Code)
+	}
+	loc := rr.Header().Get("Location")
+	if !strings.Contains(loc, "error=missing_state_or_code") {
+		t.Errorf("expected missing_state_or_code in redirect, got %q", loc)
+	}
+}
+
+func TestOAuthCallbackRejectsStateMismatch(t *testing.T) {
+	cfg := newTestOAuthConfig("github", fakeOAuthFetchUser(OAuthProfile{}))
+	deps := OAuthDeps{StateSecret: "state-secret", FrontendURL: "http://localhost:5173"}
+
+	handler := oauthCallbackHandler(cfg, deps)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/auth/github/callback?code=abc&state=foo", nil)
+	req.AddCookie(&http.Cookie{Name: oauthStateCookie + "_github", Value: "different.value"})
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusFound {
+		t.Fatalf("expected 302, got %d", rr.Code)
+	}
+	loc := rr.Header().Get("Location")
+	if !strings.Contains(loc, "error=state_mismatch") {
+		t.Errorf("expected state_mismatch in redirect, got %q", loc)
+	}
+}
+
+func TestOAuthCallbackInvalidStateSignature(t *testing.T) {
+	cfg := newTestOAuthConfig("github", fakeOAuthFetchUser(OAuthProfile{}))
+	deps := OAuthDeps{StateSecret: "state-secret", FrontendURL: "http://localhost:5173"}
+
+	handler := oauthCallbackHandler(cfg, deps)
+	rr := httptest.NewRecorder()
+	tampered := "raw." + signState("raw", "wrong-secret")
+	req := httptest.NewRequest(http.MethodGet, "/auth/github/callback?code=abc&state="+tampered, nil)
+	req.AddCookie(&http.Cookie{Name: oauthStateCookie + "_github", Value: tampered})
+	handler.ServeHTTP(rr, req)
+
+	loc := rr.Header().Get("Location")
+	if !strings.Contains(loc, "error=state_invalid") {
+		t.Errorf("expected state_invalid in redirect, got %q", loc)
+	}
+}
+
+func TestOAuthCallbackPropagatesProviderError(t *testing.T) {
+	cfg := newTestOAuthConfig("github", fakeOAuthFetchUser(OAuthProfile{}))
+	deps := OAuthDeps{StateSecret: "state-secret", FrontendURL: "http://localhost:5173"}
+
+	handler := oauthCallbackHandler(cfg, deps)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/auth/github/callback?error=access_denied", nil)
+	handler.ServeHTTP(rr, req)
+
+	loc := rr.Header().Get("Location")
+	if !strings.Contains(loc, "error=access_denied") {
+		t.Errorf("expected access_denied in redirect, got %q", loc)
+	}
+}
+
+func TestOAuthCallbackSucceeds(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	profile := OAuthProfile{
+		ProviderUserID: "12345",
+		Email:          "alice@example.com",
+		DisplayName:    "Alice",
+		AvatarURL:      "https://avatars.example.com/alice.png",
+	}
+	cfg := newTestOAuthConfig("google", fakeOAuthFetchUser(profile))
+
+	deps := OAuthDeps{
+		DB:          db,
+		JWTSecret:   "jwt-secret",
+		StateSecret: "state-secret",
+		FrontendURL: "http://localhost:5173",
+		ExchangeCodeToken: func(ctx context.Context, c OAuthProviderConfig, code string) (string, error) {
+			return "fake-access-token", nil
+		},
+	}
+
+	handler := oauthCallbackHandler(cfg, deps)
+
+	// Build a valid state value and matching cookie.
+	rawState := "raw-state-value"
+	signed := rawState + "." + signState(rawState, deps.StateSecret)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/auth/google/callback?code=abc&state="+url.QueryEscape(signed), nil)
+	req.AddCookie(&http.Cookie{Name: oauthStateCookie + "_google", Value: signed})
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusFound {
+		t.Fatalf("expected 302, got %d (body=%q)", rr.Code, rr.Body.String())
+	}
+	loc := rr.Header().Get("Location")
+	if !strings.HasPrefix(loc, "http://localhost:5173/auth/callback#") {
+		t.Fatalf("expected redirect to /auth/callback, got %q", loc)
+	}
+
+	// Parse the fragment.
+	hashIdx := strings.Index(loc, "#")
+	frag, err := url.ParseQuery(loc[hashIdx+1:])
+	if err != nil {
+		t.Fatalf("parse fragment: %v", err)
+	}
+	if frag.Get("provider") != "google" {
+		t.Errorf("expected provider=google, got %q", frag.Get("provider"))
+	}
+	if frag.Get("jwt") == "" {
+		t.Error("expected jwt in fragment")
+	}
+	if frag.Get("refresh_token") == "" {
+		t.Error("expected refresh_token in fragment")
+	}
+	if frag.Get("error") != "" {
+		t.Errorf("unexpected error: %q", frag.Get("error"))
+	}
+
+	// Verify JWT contains the user's display name and is_guest=false.
+	claims, err := ParseGuestToken(frag.Get("jwt"), deps.JWTSecret)
+	if err != nil {
+		t.Fatalf("parse jwt: %v", err)
+	}
+	if claims.DisplayName != profile.DisplayName {
+		t.Errorf("expected display_name=%q, got %q", profile.DisplayName, claims.DisplayName)
+	}
+	if claims.IsGuest {
+		t.Error("expected is_guest=false for OAuth user")
+	}
+
+	// Verify the user was inserted with provider info.
+	user, err := GetUserByProvider(db, "google", "12345")
+	if err != nil {
+		t.Fatalf("GetUserByProvider: %v", err)
+	}
+	if user == nil {
+		t.Fatal("expected user to exist")
+	}
+	if user.Email != profile.Email {
+		t.Errorf("expected email=%q, got %q", profile.Email, user.Email)
+	}
+	if user.PasswordHash.Valid {
+		t.Error("expected password_hash to be NULL for OAuth user")
+	}
+	if !user.AvatarURL.Valid || user.AvatarURL.String != profile.AvatarURL {
+		t.Errorf("expected avatar_url=%q, got %+v", profile.AvatarURL, user.AvatarURL)
+	}
+}
+
+func TestOAuthCallbackUpdatesExistingUserByEmail(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	// Pre-create an email/password user.
+	hash, _ := HashPassword("password123")
+	existing, err := CreateUser(db, "alice@example.com", hash, "Old Display")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	profile := OAuthProfile{
+		ProviderUserID: "12345",
+		Email:          "alice@example.com",
+		DisplayName:    "Alice From Google",
+		AvatarURL:      "https://avatars.example.com/alice.png",
+	}
+	cfg := newTestOAuthConfig("google", fakeOAuthFetchUser(profile))
+
+	deps := OAuthDeps{
+		DB:          db,
+		JWTSecret:   "jwt-secret",
+		StateSecret: "state-secret",
+		FrontendURL: "http://localhost:5173",
+		ExchangeCodeToken: func(ctx context.Context, c OAuthProviderConfig, code string) (string, error) {
+			return "fake-access-token", nil
+		},
+	}
+
+	handler := oauthCallbackHandler(cfg, deps)
+	rawState := "raw-state-value"
+	signed := rawState + "." + signState(rawState, deps.StateSecret)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/auth/google/callback?code=abc&state="+url.QueryEscape(signed), nil)
+	req.AddCookie(&http.Cookie{Name: oauthStateCookie + "_google", Value: signed})
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusFound {
+		t.Fatalf("expected 302, got %d", rr.Code)
+	}
+
+	updated, err := GetUserByID(db, existing.ID)
+	if err != nil {
+		t.Fatalf("GetUserByID: %v", err)
+	}
+	if updated == nil {
+		t.Fatal("expected user to exist")
+	}
+	if updated.DisplayName != profile.DisplayName {
+		t.Errorf("expected display_name=%q, got %q", profile.DisplayName, updated.DisplayName)
+	}
+	if !updated.Provider.Valid || updated.Provider.String != "google" {
+		t.Errorf("expected provider=google, got %+v", updated.Provider)
+	}
+	if !updated.ProviderUserID.Valid || updated.ProviderUserID.String != "12345" {
+		t.Errorf("expected provider_user_id=12345, got %+v", updated.ProviderUserID)
+	}
+	// Original password hash should still be present so the user can also log in via email/password.
+	if !updated.PasswordHash.Valid {
+		t.Error("expected password_hash to remain set on existing user")
+	}
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -123,7 +123,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -444,7 +443,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -493,9 +491,31 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1451,7 +1471,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1498,7 +1519,6 @@
       "integrity": "sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1509,7 +1529,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1520,7 +1539,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1570,7 +1588,6 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -1914,7 +1931,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1955,6 +1971,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1965,6 +1982,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2058,7 +2076,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2238,7 +2255,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.352",
@@ -2310,7 +2328,6 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3184,6 +3201,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3385,7 +3403,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3485,6 +3502,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3509,7 +3527,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3519,7 +3536,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3532,7 +3548,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-router": {
       "version": "7.15.0",
@@ -3881,7 +3898,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3978,7 +3994,6 @@
       "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4275,7 +4290,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -18,6 +18,17 @@ vi.mock('./api/auth', () => ({
   postGuest: vi.fn(),
   postLogin: vi.fn(),
   postRegister: vi.fn(),
+  getOAuthStartUrl: (provider: string) => `http://localhost:8080/auth/${provider}`,
+  parseOAuthCallbackFragment: (fragment: string) => {
+    const cleaned = fragment.startsWith('#') ? fragment.slice(1) : fragment
+    const params = new URLSearchParams(cleaned)
+    return {
+      provider: params.get('provider') ?? '',
+      jwt: params.get('jwt') ?? undefined,
+      refreshToken: params.get('refresh_token') ?? undefined,
+      error: params.get('error') ?? undefined,
+    }
+  },
 }))
 
 afterEach(() => {
@@ -112,7 +123,7 @@ test('guest submit calls guest auth and navigates to lobby', async () => {
   renderRoute('/auth')
 
   fireEvent.change(screen.getByLabelText(/Display name/i), { target: { value: 'Guest Player' } })
-  fireEvent.click(screen.getByRole('button', { name: /Continue/i }))
+  fireEvent.click(screen.getByRole('button', { name: /^Continue$/i }))
 
   await waitFor(() => {
     expect(postGuest).toHaveBeenCalledWith('Guest Player')
@@ -177,4 +188,66 @@ test('register submit stays blocked until fields and terms are valid', async () 
   await waitFor(() => {
     expect(screen.getByRole('heading', { name: /Game lobby/i })).toBeInTheDocument()
   })
+})
+
+test('auth page renders Google and GitHub OAuth buttons', () => {
+  renderRoute('/auth')
+
+  expect(screen.getByRole('button', { name: /Continue with Google/i })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /Continue with GitHub/i })).toBeInTheDocument()
+})
+
+test('clicking Google OAuth button navigates to backend start URL', () => {
+  renderRoute('/auth')
+
+  const originalLocation = window.location
+  const assignSpy = vi.fn()
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: {
+      ...originalLocation,
+      assign: assignSpy,
+      set href(value: string) {
+        assignSpy(value)
+      },
+    },
+  })
+
+  try {
+    fireEvent.click(screen.getByRole('button', { name: /Continue with Google/i }))
+    expect(assignSpy).toHaveBeenCalledWith('http://localhost:8080/auth/google')
+  } finally {
+    Object.defineProperty(window, 'location', { configurable: true, value: originalLocation })
+  }
+})
+
+test('OAuth callback stores tokens and redirects to lobby', async () => {
+  // Set the URL fragment to simulate the backend redirect
+  window.history.replaceState(null, '', '/auth/callback#provider=google&jwt=oauth-jwt&refresh_token=oauth-refresh')
+
+  render(
+    <MemoryRouter initialEntries={[{ pathname: '/auth/callback', hash: '#provider=google&jwt=oauth-jwt&refresh_token=oauth-refresh' }]}>
+      <App />
+    </MemoryRouter>,
+  )
+
+  await waitFor(() => {
+    expect(screen.getByRole('heading', { name: /Game lobby/i })).toBeInTheDocument()
+  })
+  expect(localStorage.getItem('seven_spade_auth_token')).toBe('oauth-jwt')
+  expect(localStorage.getItem('seven_spade_refresh_token')).toBe('oauth-refresh')
+})
+
+test('OAuth callback shows error message on failure', async () => {
+  render(
+    <MemoryRouter initialEntries={[{ pathname: '/auth/callback', hash: '#provider=google&error=access_denied' }]}>
+      <App />
+    </MemoryRouter>,
+  )
+
+  await waitFor(() => {
+    expect(screen.getByRole('heading', { name: /Sign-in failed/i })).toBeInTheDocument()
+  })
+  expect(screen.getByText(/cancelled the sign-in/i)).toBeInTheDocument()
+  expect(localStorage.getItem('seven_spade_auth_token')).toBeNull()
 })

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { Navigate, NavLink, Route, Routes, useLocation } from "react-router";
 import { AuthPage } from "./pages/AuthPage";
+import { OAuthCallbackPage } from "./pages/OAuthCallbackPage";
 import { RegisterPage } from "./pages/RegisterPage";
 import { GamePage } from "./pages/GamePage";
 import { HistoryPage } from "./pages/HistoryPage";
@@ -8,7 +9,7 @@ import { ResultsPage } from "./pages/ResultsPage";
 
 function App() {
   const { pathname } = useLocation();
-  const hideHeader = pathname === "/auth" || pathname === "/register" || pathname === "/login";
+  const hideHeader = pathname === "/auth" || pathname === "/register" || pathname === "/login" || pathname === "/auth/callback";
 
   return (
     <div className="min-h-svh bg-spade-bg text-spade-cream">
@@ -31,6 +32,7 @@ function App() {
         <Routes>
           <Route index element={<Navigate replace to="/auth" />} />
           <Route path="/auth" element={<AuthPage />} />
+          <Route path="/auth/callback" element={<OAuthCallbackPage />} />
           <Route path="/login" element={<Navigate replace to="/auth" />} />
           <Route path="/register" element={<RegisterPage />} />
           <Route path="/lobby" element={<LobbyPage />} />

--- a/web/src/api/auth.test.ts
+++ b/web/src/api/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { postRegister, postLogin, postRefresh, AuthApiError } from './auth'
+import { postRegister, postLogin, postRefresh, AuthApiError, parseOAuthCallbackFragment, getOAuthStartUrl } from './auth'
 
 describe('postRegister', () => {
   beforeEach(() => {
@@ -155,5 +155,44 @@ describe('postRefresh', () => {
     )
 
     await expect(postRefresh('invalid-token')).rejects.toThrow(AuthApiError)
+  })
+})
+
+describe('getOAuthStartUrl', () => {
+  it('returns the API URL for the given provider', () => {
+    expect(getOAuthStartUrl('google')).toBe('http://localhost:8080/auth/google')
+    expect(getOAuthStartUrl('github')).toBe('http://localhost:8080/auth/github')
+  })
+})
+
+describe('parseOAuthCallbackFragment', () => {
+  it('parses a successful callback fragment', () => {
+    const result = parseOAuthCallbackFragment('#provider=google&jwt=jwt-value&refresh_token=refresh-value')
+    expect(result.provider).toBe('google')
+    expect(result.jwt).toBe('jwt-value')
+    expect(result.refreshToken).toBe('refresh-value')
+    expect(result.error).toBeUndefined()
+  })
+
+  it('parses an error callback fragment', () => {
+    const result = parseOAuthCallbackFragment('#provider=github&error=access_denied')
+    expect(result.provider).toBe('github')
+    expect(result.error).toBe('access_denied')
+    expect(result.jwt).toBeUndefined()
+    expect(result.refreshToken).toBeUndefined()
+  })
+
+  it('handles fragment without leading #', () => {
+    const result = parseOAuthCallbackFragment('provider=google&jwt=abc')
+    expect(result.provider).toBe('google')
+    expect(result.jwt).toBe('abc')
+  })
+
+  it('returns empty fields for an empty fragment', () => {
+    const result = parseOAuthCallbackFragment('')
+    expect(result.provider).toBe('')
+    expect(result.jwt).toBeUndefined()
+    expect(result.refreshToken).toBeUndefined()
+    expect(result.error).toBeUndefined()
   })
 })

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -186,3 +186,36 @@ export async function postRefresh(refreshToken: string): Promise<RefreshResponse
 
   return response.json() as Promise<RefreshResponse>;
 }
+
+export type OAuthProvider = 'google' | 'github';
+
+/**
+ * Build the URL the browser should navigate to in order to start the OAuth flow
+ * for the given provider. The backend redirects to the provider's consent screen
+ * and ultimately back to /auth/callback in the SPA.
+ */
+export function getOAuthStartUrl(provider: OAuthProvider): string {
+  return `${API_URL}/auth/${provider}`;
+}
+
+export interface OAuthCallbackResult {
+  provider: OAuthProvider | string;
+  jwt?: string;
+  refreshToken?: string;
+  error?: string;
+}
+
+/**
+ * Parse the URL fragment that the backend appends after a successful or failed
+ * OAuth callback (e.g. `#provider=google&jwt=...&refresh_token=...`).
+ */
+export function parseOAuthCallbackFragment(fragment: string): OAuthCallbackResult {
+  const cleaned = fragment.startsWith('#') ? fragment.slice(1) : fragment;
+  const params = new URLSearchParams(cleaned);
+  return {
+    provider: params.get('provider') ?? '',
+    jwt: params.get('jwt') ?? undefined,
+    refreshToken: params.get('refresh_token') ?? undefined,
+    error: params.get('error') ?? undefined,
+  };
+}

--- a/web/src/pages/AuthPage.tsx
+++ b/web/src/pages/AuthPage.tsx
@@ -1,7 +1,7 @@
 import { type FormEvent, useState } from 'react'
 import { useNavigate, Link } from 'react-router'
 import { Button } from '../components/Button'
-import { postGuest, postLogin, AuthApiError } from '../api/auth'
+import { postGuest, postLogin, AuthApiError, getOAuthStartUrl } from '../api/auth'
 import { useAuth } from '../hooks/useAuth'
 
 export function AuthPage() {
@@ -57,6 +57,10 @@ export function AuthPage() {
     } finally {
       setLoginIsLoading(false)
     }
+  }
+
+  const handleOAuth = (provider: 'google' | 'github') => {
+    window.location.href = getOAuthStartUrl(provider)
   }
 
   return (
@@ -171,6 +175,40 @@ export function AuthPage() {
                 {loginIsLoading ? 'Signing in...' : 'Sign In'}
               </Button>
             </form>
+
+            <div className="my-5 flex items-center gap-3">
+              <div className="h-px flex-1 bg-spade-cream/12" />
+              <span className="font-mono text-[10px] uppercase tracking-wider text-spade-gray-3">Or continue with</span>
+              <div className="h-px flex-1 bg-spade-cream/12" />
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <button
+                type="button"
+                onClick={() => handleOAuth('google')}
+                className="inline-flex min-h-9 items-center justify-center gap-2 rounded-spade-md border border-spade-cream/18 bg-transparent px-4 py-2.5 text-sm font-medium text-spade-cream transition hover:bg-spade-cream/8 active:scale-95 disabled:cursor-not-allowed disabled:opacity-40"
+                aria-label="Continue with Google"
+              >
+                <svg viewBox="0 0 24 24" className="size-4" aria-hidden="true">
+                  <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.56c2.08-1.92 3.28-4.74 3.28-8.1z" />
+                  <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.56-2.77c-.99.66-2.25 1.06-3.72 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84A11 11 0 0 0 12 23z" />
+                  <path fill="#FBBC05" d="M5.84 14.1A6.6 6.6 0 0 1 5.5 12c0-.73.13-1.44.34-2.1V7.07H2.18A11 11 0 0 0 1 12c0 1.78.43 3.46 1.18 4.94l3.66-2.84z" />
+                  <path fill="#EA4335" d="M12 5.38c1.62 0 3.07.56 4.21 1.65l3.15-3.15C17.45 2.09 14.97 1 12 1A11 11 0 0 0 2.18 7.07l3.66 2.83C6.71 7.31 9.14 5.38 12 5.38z" />
+                </svg>
+                Google
+              </button>
+              <button
+                type="button"
+                onClick={() => handleOAuth('github')}
+                className="inline-flex min-h-9 items-center justify-center gap-2 rounded-spade-md border border-spade-cream/18 bg-transparent px-4 py-2.5 text-sm font-medium text-spade-cream transition hover:bg-spade-cream/8 active:scale-95 disabled:cursor-not-allowed disabled:opacity-40"
+                aria-label="Continue with GitHub"
+              >
+                <svg viewBox="0 0 24 24" className="size-4 fill-spade-cream" aria-hidden="true">
+                  <path d="M12 .5A11.5 11.5 0 0 0 .5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-1.97c-3.2.7-3.87-1.54-3.87-1.54-.52-1.33-1.28-1.69-1.28-1.69-1.05-.72.08-.71.08-.71 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.16 1.17a10.94 10.94 0 0 1 5.75 0c2.2-1.48 3.16-1.17 3.16-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.13v3.16c0 .31.21.66.8.55A11.5 11.5 0 0 0 23.5 12 11.5 11.5 0 0 0 12 .5z" />
+                </svg>
+                GitHub
+              </button>
+            </div>
 
             <div className="mt-5 text-center text-sm text-spade-gray-3">
               Don't have an account?{' '}

--- a/web/src/pages/OAuthCallbackPage.tsx
+++ b/web/src/pages/OAuthCallbackPage.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { useLocation, useNavigate } from 'react-router'
+import { parseOAuthCallbackFragment } from '../api/auth'
+import { useAuth } from '../hooks/useAuth'
+
+const errorMessages: Record<string, string> = {
+  access_denied: 'You cancelled the sign-in.',
+  missing_state_or_code: 'OAuth response was incomplete. Please try again.',
+  missing_state_cookie: 'Sign-in session expired. Please try again.',
+  state_mismatch: 'Sign-in session could not be verified. Please try again.',
+  state_invalid: 'Sign-in session was tampered with. Please try again.',
+  token_exchange_failed: 'Could not complete sign-in with the provider. Please try again.',
+  profile_fetch_failed: 'Could not load your profile from the provider. Please try again.',
+  no_email: 'The provider did not return an email address. Try a different sign-in method.',
+  upsert_failed: 'Could not save your account. Please try again.',
+  jwt_failed: 'Could not issue a session. Please try again.',
+  refresh_failed: 'Could not issue a session. Please try again.',
+  store_refresh_failed: 'Could not save your session. Please try again.',
+}
+
+function resolveErrorMessage(code: string): string {
+  return errorMessages[code] ?? `Sign-in failed: ${code}`
+}
+
+export function OAuthCallbackPage() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { login } = useAuth()
+  const handled = useRef(false)
+
+  // Compute the OAuth result synchronously so we don't have to setState inside an effect.
+  // Falling back to window.location.hash keeps real-browser navigation working when the
+  // router hasn't been seeded with the hash (e.g. after an external redirect).
+  const result = useMemo(() => {
+    const hash = location.hash || (typeof window !== 'undefined' ? window.location.hash : '')
+    return parseOAuthCallbackFragment(hash)
+  }, [location.hash])
+
+  const errorMessage = result.error
+    ? resolveErrorMessage(result.error)
+    : !result.jwt
+      ? 'Sign-in did not return a session token. Please try again.'
+      : null
+
+  useEffect(() => {
+    if (handled.current) {
+      return
+    }
+    handled.current = true
+
+    // Strip the fragment so the JWT doesn't sit in the URL on subsequent reloads.
+    if (typeof window !== 'undefined' && window.history.replaceState) {
+      window.history.replaceState(null, '', window.location.pathname + window.location.search)
+    }
+
+    if (errorMessage) {
+      return
+    }
+
+    if (result.jwt) {
+      login(result.jwt, result.refreshToken)
+      navigate('/lobby', { replace: true })
+    }
+  }, [errorMessage, login, navigate, result.jwt, result.refreshToken])
+
+  return (
+    <section className="grid min-h-svh place-items-center bg-spade-bg px-4">
+      <div className="w-full max-w-md rounded-spade-lg border border-spade-cream/10 bg-[#102316] p-6 shadow-spade-card">
+        <div className="flex items-center gap-3">
+          <span className="grid size-9 place-items-center rounded-spade-md bg-spade-green-mid text-spade-gold-light">♠</span>
+          <h2 className="text-xl font-medium">{errorMessage ? 'Sign-in failed' : 'Signing you in'}</h2>
+        </div>
+        {errorMessage ? (
+          <>
+            <p className="mt-3 text-sm text-spade-gray-2">{errorMessage}</p>
+            <button
+              type="button"
+              onClick={() => navigate('/auth', { replace: true })}
+              className="mt-4 inline-flex min-h-9 items-center justify-center rounded-spade-md bg-spade-gold px-4 py-2 text-sm font-medium text-[#1a0e00] transition hover:bg-[#d9a030] active:scale-95"
+            >
+              Back to sign in
+            </button>
+          </>
+        ) : (
+          <p className="mt-3 text-sm text-spade-gray-2">Verifying your account and taking you to the lobby...</p>
+        )}
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
Closes #7

## Summary

Adds Google and GitHub OAuth2 login to the API and the SPA. The
backend handles the consent redirect, code exchange, profile fetch, and
upsert; the frontend gains Google + GitHub buttons on the auth screen
and a `/auth/callback` page that picks up the JWT/refresh token from
the URL fragment.

## Acceptance criteria

- [x] `GET /auth/google` redirects to Google OAuth consent; callback upserts user and returns JWT
- [x] `GET /auth/github` redirects to GitHub OAuth consent; callback upserts user and returns JWT
- [x] Existing users logging in via OAuth have their profile updated (display name, avatar)
- [x] New users created via OAuth have a row in the `users` table with provider info
- [x] React auth screen shows Google + GitHub login buttons that initiate the OAuth flow
- [x] Integration test: OAuth callback with a mocked provider token upserts user and returns valid JWT (`TestOAuthCallbackSucceeds`, `TestOAuthCallbackUpdatesExistingUserByEmail`)

## Changes

- `services/api/migrations/002_oauth_users.sql` — nullable `password_hash`,
  `provider`/`provider_user_id`/`avatar_url` columns, partial unique index
- `services/api/oauth.go` (+ `oauth_test.go`) — generic provider config,
  start + callback handlers, signed-state cookie, Google + GitHub specifics
- `services/api/models.go` — `UpsertOAuthUser`, `GetUserByProvider`,
  `PasswordHash` is now `sql.NullString`
- `services/api/main.go` — login handles NULL password hash; OAuth routes wired
- `docs/api.md` — documents the new redirect-to-fragment flow + env vars
- `web/src/api/auth.ts` — `getOAuthStartUrl`, `parseOAuthCallbackFragment`
- `web/src/pages/AuthPage.tsx` — Google + GitHub buttons inside the Sign In card
- `web/src/pages/OAuthCallbackPage.tsx` (new) — picks up the fragment, stores tokens, redirects
- `web/src/App.tsx` — `/auth/callback` route

## Decisions

- Tokens are returned in the URL **fragment** (`#jwt=...&refresh_token=...`) rather
  than a query string so they don't end up in server access logs or `Referer`
  headers. The SPA strips the fragment on mount via `history.replaceState`.
- The OAuth state cookie is **per-provider** (`oauth_state_google`,
  `oauth_state_github`) so a stalled flow on one provider doesn't break a
  fresh attempt on the other. The state itself is HMAC-signed with
  `OAUTH_STATE_SECRET` (defaults to `JWT_SECRET`).
- If an OAuth profile email matches an existing email/password user,
  the provider identity is **linked** onto that row and the password
  hash is preserved — the user can then log in with either method.
- The `FetchUser`/`ExchangeCodeToken` functions on `OAuthProviderConfig` /
  `OAuthDeps` are injectable, which lets the tests cover the full callback
  flow without hitting Google/GitHub.

## Configuration

New environment variables on `services/api`:

- `GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET`, `GOOGLE_OAUTH_REDIRECT_URL`
- `GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET`, `GITHUB_OAUTH_REDIRECT_URL`
- `FRONTEND_URL` (defaults to `http://localhost:5173`)
- `OAUTH_STATE_SECRET` (optional; defaults to `JWT_SECRET`)

When a provider's `CLIENT_ID` is unset, the start endpoint returns `503` so
the SPA can detect unconfigured providers cleanly.

## Test status

- `services/api`: 26 unit tests pass; 2 OAuth DB-integration tests skip
  without `DATABASE_URL` (same skip pattern as existing email/password
  integration tests).
- `web`: 30 unit tests pass, lint clean, build succeeds.