### PR TITLE
OAuth: Telegram

### DIFF
--- a/.sandcastle/merge-prompt.md
+++ b/.sandcastle/merge-prompt.md
@@ -11,7 +11,27 @@ For each branch:
    gh pr list --head <branch> --json number,title --jq '.[0]'
    ```
 
-2. Merge via the PR with a summary comment:
+2. Push any local changes to the target branch:
+   ```
+   git push origin HEAD
+   ```
+
+3. Check the PR for merge conflicts:
+   ```
+   gh pr view <PR_NUMBER> --json mergeable
+   ```
+
+4. If there are conflicts, resolve them locally:
+   ```
+   git merge <branch>
+   # Resolve conflicts in your editor
+   git add .
+   git commit -m "Resolve merge conflicts"
+   git push origin HEAD
+   ```
+   The PR will automatically update on GitHub.
+
+5. Merge via the PR on GitHub (do NOT merge locally):
    ```
    gh pr merge <PR_NUMBER> --merge --subject "Merge: <PR title>" --body "## Merge Summary
 
@@ -28,17 +48,16 @@ For each branch:
    All tests passing."
    ```
 
-3. If there is no open PR (e.g. branch was pushed without one), fall back to:
+6. After each merge, pull the updated main branch locally:
    ```
-   git merge <branch> --no-edit
+   git pull origin HEAD
    ```
-   Then resolve any conflicts intelligently by reading both sides and choosing the correct resolution.
 
-4. After each merge, run the relevant tests to verify everything works:
+7. Run the relevant tests to verify everything works:
    - **Go services**: `cd services/<service> && go test ./...`
    - **Frontend**: `cd web && npm run build && npm run lint`
    - **Frontend tests**: `cd web && npm test` when a test script exists or frontend tests are part of the merged branch
-   - If tests fail, fix the issues before proceeding to the next branch.
+   - If tests fail, report the issue and do NOT continue merging
 
 # CLOSE ISSUES
 

--- a/services/api/main.go
+++ b/services/api/main.go
@@ -2,14 +2,19 @@ package main
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 )
@@ -54,6 +59,16 @@ type refreshResponse struct {
 	JWT string `json:"jwt"`
 }
 
+type telegramAuthRequest struct {
+	ID        int64  `json:"id"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+	Username  string `json:"username"`
+	PhotoURL  string `json:"photo_url"`
+	AuthDate  int64  `json:"auth_date"`
+	Hash      string `json:"hash"`
+}
+
 type errorResponse struct {
 	Error string `json:"error"`
 }
@@ -90,11 +105,123 @@ func main() {
 	mux.HandleFunc("POST /register", registerHandler(db, jwtSecret))
 	mux.HandleFunc("POST /login", loginHandler(db, jwtSecret))
 	mux.HandleFunc("POST /refresh", refreshHandler(db, jwtSecret))
+	mux.HandleFunc("POST /auth/telegram", telegramAuthHandler(db, jwtSecret, os.Getenv("TELEGRAM_BOT_TOKEN")))
 
 	log.Printf("API service listening on :%s", port)
 	if err := http.ListenAndServe(":"+port, withCORS(mux)); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func telegramAuthHandler(db *sql.DB, jwtSecret string, botToken string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req telegramAuthRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(errorResponse{Error: "Invalid request body"})
+			return
+		}
+
+		if botToken == "" || !verifyTelegramPayload(req, botToken, time.Now()) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(errorResponse{Error: "Invalid or expired Telegram payload"})
+			return
+		}
+
+		displayName := telegramDisplayName(req)
+		user, err := UpsertTelegramUser(db, req.ID, displayName)
+		if err != nil {
+			log.Printf("Failed to upsert Telegram user: %v", err)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(errorResponse{Error: "Internal server error"})
+			return
+		}
+
+		jwt, err := GenerateUserToken(user.ID.String(), user.DisplayName, jwtSecret)
+		if err != nil {
+			log.Printf("Failed to generate JWT: %v", err)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(errorResponse{Error: "Internal server error"})
+			return
+		}
+
+		refreshToken, err := GenerateRefreshToken()
+		if err != nil {
+			log.Printf("Failed to generate refresh token: %v", err)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(errorResponse{Error: "Internal server error"})
+			return
+		}
+
+		tokenHash := HashRefreshToken(refreshToken)
+		if err := StoreRefreshToken(db, user.ID, tokenHash, time.Now().Add(30*24*time.Hour)); err != nil {
+			log.Printf("Failed to store refresh token: %v", err)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(errorResponse{Error: "Internal server error"})
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(authResponse{JWT: jwt, RefreshToken: refreshToken})
+	}
+}
+
+func verifyTelegramPayload(req telegramAuthRequest, botToken string, now time.Time) bool {
+	if req.ID == 0 || req.AuthDate == 0 || req.Hash == "" {
+		return false
+	}
+	if now.Sub(time.Unix(req.AuthDate, 0)) > 24*time.Hour || time.Unix(req.AuthDate, 0).After(now.Add(5*time.Minute)) {
+		return false
+	}
+
+	data := map[string]string{
+		"id":        fmt.Sprintf("%d", req.ID),
+		"auth_date": fmt.Sprintf("%d", req.AuthDate),
+	}
+	if req.FirstName != "" {
+		data["first_name"] = req.FirstName
+	}
+	if req.LastName != "" {
+		data["last_name"] = req.LastName
+	}
+	if req.Username != "" {
+		data["username"] = req.Username
+	}
+	if req.PhotoURL != "" {
+		data["photo_url"] = req.PhotoURL
+	}
+
+	parts := make([]string, 0, len(data))
+	for key, value := range data {
+		parts = append(parts, key+"="+value)
+	}
+	sort.Strings(parts)
+	secret := sha256.Sum256([]byte(botToken))
+	mac := hmac.New(sha256.New, secret[:])
+	mac.Write([]byte(strings.Join(parts, "\n")))
+	expected := hex.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(expected), []byte(strings.ToLower(req.Hash)))
+}
+
+func telegramDisplayName(req telegramAuthRequest) string {
+	displayName := strings.TrimSpace(strings.Join([]string{req.FirstName, req.LastName}, " "))
+	if displayName == "" {
+		displayName = strings.TrimSpace(req.Username)
+	}
+	if displayName == "" {
+		displayName = fmt.Sprintf("Telegram %d", req.ID)
+	}
+	if len(displayName) > 50 {
+		return displayName[:50]
+	}
+	return displayName
 }
 
 func healthHandler(service string, checks map[string]dependencyCheck) http.HandlerFunc {

--- a/services/api/main.go
+++ b/services/api/main.go
@@ -177,35 +177,38 @@ func verifyTelegramPayload(req telegramAuthRequest, botToken string, now time.Ti
 	if req.ID == 0 || req.AuthDate == 0 || req.Hash == "" {
 		return false
 	}
-	if now.Sub(time.Unix(req.AuthDate, 0)) > 24*time.Hour || time.Unix(req.AuthDate, 0).After(now.Add(5*time.Minute)) {
+	authTime := time.Unix(req.AuthDate, 0)
+	if now.Sub(authTime) > 24*time.Hour || authTime.After(now.Add(5*time.Minute)) {
 		return false
 	}
 
-	data := map[string]string{
+	checkStringFields := map[string]string{
 		"id":        fmt.Sprintf("%d", req.ID),
 		"auth_date": fmt.Sprintf("%d", req.AuthDate),
 	}
 	if req.FirstName != "" {
-		data["first_name"] = req.FirstName
+		checkStringFields["first_name"] = req.FirstName
 	}
 	if req.LastName != "" {
-		data["last_name"] = req.LastName
+		checkStringFields["last_name"] = req.LastName
 	}
 	if req.Username != "" {
-		data["username"] = req.Username
+		checkStringFields["username"] = req.Username
 	}
 	if req.PhotoURL != "" {
-		data["photo_url"] = req.PhotoURL
+		checkStringFields["photo_url"] = req.PhotoURL
 	}
 
-	parts := make([]string, 0, len(data))
-	for key, value := range data {
-		parts = append(parts, key+"="+value)
+	checkStringParts := make([]string, 0, len(checkStringFields))
+	for key, value := range checkStringFields {
+		checkStringParts = append(checkStringParts, key+"="+value)
 	}
-	sort.Strings(parts)
+	sort.Strings(checkStringParts)
+	checkString := strings.Join(checkStringParts, "\n")
+
 	secret := sha256.Sum256([]byte(botToken))
 	mac := hmac.New(sha256.New, secret[:])
-	mac.Write([]byte(strings.Join(parts, "\n")))
+	mac.Write([]byte(checkString))
 	expected := hex.EncodeToString(mac.Sum(nil))
 	return hmac.Equal([]byte(expected), []byte(strings.ToLower(req.Hash)))
 }

--- a/services/api/main_test.go
+++ b/services/api/main_test.go
@@ -581,8 +581,3 @@ func signedTelegramPayload(t *testing.T, botToken string, data map[string]string
 	payload["hash"] = hex.EncodeToString(mac.Sum(nil))
 	return payload
 }
-
-// testNow returns the current time (helper for tests)
-func testNow() time.Time {
-	return time.Now()
-}

--- a/services/api/main_test.go
+++ b/services/api/main_test.go
@@ -470,7 +470,7 @@ func TestRefreshHandler(t *testing.T) {
 	// Create a refresh token
 	refreshToken, _ := GenerateRefreshToken()
 	tokenHash := HashRefreshToken(refreshToken)
-	expiresAt := testNow().Add(30 * 24 * time.Hour)
+	expiresAt := time.Now().Add(30 * 24 * time.Hour)
 	if err := StoreRefreshToken(db, user.ID, tokenHash, expiresAt); err != nil {
 		t.Fatalf("failed to store refresh token: %v", err)
 	}
@@ -558,6 +558,30 @@ func TestTelegramAuthHandlerAcceptsValidPayloadAndRejectsTamperedPayload(t *test
 	}
 	recorder = httptest.NewRecorder()
 	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/auth/telegram", bytes.NewReader(tamperedBody)))
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, recorder.Code)
+	}
+}
+
+func TestTelegramAuthHandlerRejectsExpiredPayload(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	botToken := "123456:test-bot-token"
+	handler := telegramAuthHandler(db, "test-secret", botToken)
+	payload := signedTelegramPayload(t, botToken, map[string]string{
+		"id":         "987654321",
+		"first_name": "Ada",
+		"auth_date":  strconv.FormatInt(time.Now().Add(-25*time.Hour).Unix(), 10),
+	})
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/auth/telegram", bytes.NewReader(body)))
+
 	if recorder.Code != http.StatusUnauthorized {
 		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, recorder.Code)
 	}

--- a/services/api/main_test.go
+++ b/services/api/main_test.go
@@ -3,12 +3,17 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -191,68 +196,68 @@ func TestGuestHandlerTrimsWhitespaceFromDisplayName(t *testing.T) {
 // setupTestDB creates a test database connection for integration tests
 func setupTestDB(t *testing.T) *sql.DB {
 	t.Helper()
-	
+
 	// Skip if no DATABASE_URL is set
 	databaseURL := os.Getenv("DATABASE_URL")
 	if databaseURL == "" {
 		t.Skip("DATABASE_URL not set, skipping integration tests")
 	}
-	
+
 	db, err := InitDB(databaseURL)
 	if err != nil {
 		t.Fatalf("Failed to initialize test database: %v", err)
 	}
-	
+
 	// Clean up test data before each test
 	_, _ = db.Exec("DELETE FROM refresh_tokens")
 	_, _ = db.Exec("DELETE FROM users")
-	
+
 	return db
 }
 
 func TestRegisterHandler(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
-	
+
 	secret := "test-secret"
 	handler := registerHandler(db, secret)
-	
+
 	body := bytes.NewBufferString(`{
 		"email": "test@example.com",
 		"password": "password123",
 		"display_name": "Test User"
 	}`)
-	
+
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/register", body))
-	
+
 	if recorder.Code != http.StatusCreated {
 		t.Fatalf("expected status %d, got %d", http.StatusCreated, recorder.Code)
 	}
-	
+
 	var response authResponse
 	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	
+
 	if response.JWT == "" {
 		t.Fatal("expected non-empty JWT")
 	}
-	
+
 	if response.RefreshToken == "" {
 		t.Fatal("expected non-empty refresh token")
 	}
-	
+
 	// Verify JWT claims
 	claims, err := ParseGuestToken(response.JWT, secret)
 	if err != nil {
 		t.Fatalf("failed to parse JWT: %v", err)
 	}
-	
+
 	if claims.DisplayName != "Test User" {
 		t.Errorf("expected display_name 'Test User', got %q", claims.DisplayName)
 	}
-	
+
 	if claims.IsGuest {
 		t.Error("expected is_guest to be false for registered user")
 	}
@@ -261,9 +266,9 @@ func TestRegisterHandler(t *testing.T) {
 func TestRegisterHandlerRejectsInvalidEmail(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
-	
+
 	handler := registerHandler(db, "test-secret")
-	
+
 	tests := []struct {
 		name  string
 		email string
@@ -273,7 +278,7 @@ func TestRegisterHandlerRejectsInvalidEmail(t *testing.T) {
 		{"missing username", "@example.com"},
 		{"invalid format", "test@example"},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			body := bytes.NewBufferString(`{
@@ -281,10 +286,10 @@ func TestRegisterHandlerRejectsInvalidEmail(t *testing.T) {
 				"password": "password123",
 				"display_name": "Test User"
 			}`)
-			
+
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/register", body))
-			
+
 			if recorder.Code != http.StatusBadRequest {
 				t.Errorf("expected status %d, got %d", http.StatusBadRequest, recorder.Code)
 			}
@@ -295,27 +300,27 @@ func TestRegisterHandlerRejectsInvalidEmail(t *testing.T) {
 func TestRegisterHandlerRejectsWeakPassword(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
-	
+
 	handler := registerHandler(db, "test-secret")
-	
+
 	body := bytes.NewBufferString(`{
 		"email": "test@example.com",
 		"password": "short",
 		"display_name": "Test User"
 	}`)
-	
+
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/register", body))
-	
+
 	if recorder.Code != http.StatusBadRequest {
 		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, recorder.Code)
 	}
-	
+
 	var response errorResponse
 	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	
+
 	if !strings.Contains(strings.ToLower(response.Error), "8 characters") {
 		t.Errorf("expected error about password length, got %q", response.Error)
 	}
@@ -324,9 +329,9 @@ func TestRegisterHandlerRejectsWeakPassword(t *testing.T) {
 func TestRegisterHandlerRejectsDuplicateEmail(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
-	
+
 	handler := registerHandler(db, "test-secret")
-	
+
 	// Register first user
 	body1 := bytes.NewBufferString(`{
 		"email": "test@example.com",
@@ -335,11 +340,11 @@ func TestRegisterHandlerRejectsDuplicateEmail(t *testing.T) {
 	}`)
 	recorder1 := httptest.NewRecorder()
 	handler.ServeHTTP(recorder1, httptest.NewRequest(http.MethodPost, "/register", body1))
-	
+
 	if recorder1.Code != http.StatusCreated {
 		t.Fatalf("first registration failed with status %d", recorder1.Code)
 	}
-	
+
 	// Try to register with same email
 	body2 := bytes.NewBufferString(`{
 		"email": "test@example.com",
@@ -348,16 +353,16 @@ func TestRegisterHandlerRejectsDuplicateEmail(t *testing.T) {
 	}`)
 	recorder2 := httptest.NewRecorder()
 	handler.ServeHTTP(recorder2, httptest.NewRequest(http.MethodPost, "/register", body2))
-	
+
 	if recorder2.Code != http.StatusConflict {
 		t.Fatalf("expected status %d, got %d", http.StatusConflict, recorder2.Code)
 	}
-	
+
 	var response errorResponse
 	if err := json.NewDecoder(recorder2.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	
+
 	if !strings.Contains(strings.ToLower(response.Error), "already registered") {
 		t.Errorf("expected error about duplicate email, got %q", response.Error)
 	}
@@ -366,39 +371,39 @@ func TestRegisterHandlerRejectsDuplicateEmail(t *testing.T) {
 func TestLoginHandler(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
-	
+
 	secret := "test-secret"
-	
+
 	// First register a user
 	passwordHash, _ := HashPassword("password123")
 	_, err := CreateUser(db, "test@example.com", passwordHash, "Test User")
 	if err != nil {
 		t.Fatalf("failed to create test user: %v", err)
 	}
-	
+
 	handler := loginHandler(db, secret)
-	
+
 	body := bytes.NewBufferString(`{
 		"email": "test@example.com",
 		"password": "password123"
 	}`)
-	
+
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/login", body))
-	
+
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("expected status %d, got %d", http.StatusOK, recorder.Code)
 	}
-	
+
 	var response authResponse
 	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	
+
 	if response.JWT == "" {
 		t.Fatal("expected non-empty JWT")
 	}
-	
+
 	if response.RefreshToken == "" {
 		t.Fatal("expected non-empty refresh token")
 	}
@@ -407,24 +412,24 @@ func TestLoginHandler(t *testing.T) {
 func TestLoginHandlerRejectsWrongPassword(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
-	
+
 	// Register a user
 	passwordHash, _ := HashPassword("password123")
 	_, err := CreateUser(db, "test@example.com", passwordHash, "Test User")
 	if err != nil {
 		t.Fatalf("failed to create test user: %v", err)
 	}
-	
+
 	handler := loginHandler(db, "test-secret")
-	
+
 	body := bytes.NewBufferString(`{
 		"email": "test@example.com",
 		"password": "wrongpassword"
 	}`)
-	
+
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/login", body))
-	
+
 	if recorder.Code != http.StatusUnauthorized {
 		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, recorder.Code)
 	}
@@ -433,17 +438,17 @@ func TestLoginHandlerRejectsWrongPassword(t *testing.T) {
 func TestLoginHandlerRejectsNonExistentUser(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
-	
+
 	handler := loginHandler(db, "test-secret")
-	
+
 	body := bytes.NewBufferString(`{
 		"email": "nonexistent@example.com",
 		"password": "password123"
 	}`)
-	
+
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/login", body))
-	
+
 	if recorder.Code != http.StatusUnauthorized {
 		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, recorder.Code)
 	}
@@ -452,16 +457,16 @@ func TestLoginHandlerRejectsNonExistentUser(t *testing.T) {
 func TestRefreshHandler(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
-	
+
 	secret := "test-secret"
-	
+
 	// Create a test user
 	passwordHash, _ := HashPassword("password123")
 	user, err := CreateUser(db, "test@example.com", passwordHash, "Test User")
 	if err != nil {
 		t.Fatalf("failed to create test user: %v", err)
 	}
-	
+
 	// Create a refresh token
 	refreshToken, _ := GenerateRefreshToken()
 	tokenHash := HashRefreshToken(refreshToken)
@@ -469,22 +474,22 @@ func TestRefreshHandler(t *testing.T) {
 	if err := StoreRefreshToken(db, user.ID, tokenHash, expiresAt); err != nil {
 		t.Fatalf("failed to store refresh token: %v", err)
 	}
-	
+
 	handler := refreshHandler(db, secret)
-	
+
 	body := bytes.NewBufferString(`{"refresh_token": "` + refreshToken + `"}`)
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/refresh", body))
-	
+
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("expected status %d, got %d", http.StatusOK, recorder.Code)
 	}
-	
+
 	var response refreshResponse
 	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	
+
 	if response.JWT == "" {
 		t.Fatal("expected non-empty JWT")
 	}
@@ -493,16 +498,88 @@ func TestRefreshHandler(t *testing.T) {
 func TestRefreshHandlerRejectsInvalidToken(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
-	
+
 	handler := refreshHandler(db, "test-secret")
-	
+
 	body := bytes.NewBufferString(`{"refresh_token": "invalid-token"}`)
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/refresh", body))
-	
+
 	if recorder.Code != http.StatusUnauthorized {
 		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, recorder.Code)
 	}
+}
+
+func TestTelegramAuthHandlerAcceptsValidPayloadAndRejectsTamperedPayload(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	botToken := "123456:test-bot-token"
+	jwtSecret := "test-secret"
+	handler := telegramAuthHandler(db, jwtSecret, botToken)
+	payload := signedTelegramPayload(t, botToken, map[string]string{
+		"id":         "987654321",
+		"first_name": "Ada",
+		"last_name":  "Lovelace",
+		"username":   "ada",
+		"auth_date":  strconv.FormatInt(time.Now().Unix(), 10),
+	})
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/auth/telegram", bytes.NewReader(body)))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, recorder.Code, recorder.Body.String())
+	}
+
+	var response authResponse
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.JWT == "" || response.RefreshToken == "" {
+		t.Fatalf("expected jwt and refresh token, got %+v", response)
+	}
+	claims, err := ParseGuestToken(response.JWT, jwtSecret)
+	if err != nil {
+		t.Fatalf("parse jwt: %v", err)
+	}
+	if claims.DisplayName != "Ada Lovelace" || claims.IsGuest {
+		t.Fatalf("unexpected claims: %+v", claims)
+	}
+
+	payload["first_name"] = "Grace"
+	tamperedBody, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal tampered payload: %v", err)
+	}
+	recorder = httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/auth/telegram", bytes.NewReader(tamperedBody)))
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, recorder.Code)
+	}
+}
+
+func signedTelegramPayload(t *testing.T, botToken string, data map[string]string) map[string]string {
+	t.Helper()
+	checkParts := make([]string, 0, len(data))
+	for key, value := range data {
+		checkParts = append(checkParts, key+"="+value)
+	}
+	sort.Strings(checkParts)
+	secret := sha256.Sum256([]byte(botToken))
+	mac := hmac.New(sha256.New, secret[:])
+	mac.Write([]byte(strings.Join(checkParts, "\n")))
+
+	payload := make(map[string]string, len(data)+1)
+	for key, value := range data {
+		payload[key] = value
+	}
+	payload["hash"] = hex.EncodeToString(mac.Sum(nil))
+	return payload
 }
 
 // testNow returns the current time (helper for tests)

--- a/services/api/migrations/002_add_auth_provider_fields.sql
+++ b/services/api/migrations/002_add_auth_provider_fields.sql
@@ -1,0 +1,11 @@
+ALTER TABLE users
+    ALTER COLUMN password_hash DROP NOT NULL,
+    ADD COLUMN IF NOT EXISTS auth_provider VARCHAR(32) NOT NULL DEFAULT 'password',
+    ADD COLUMN IF NOT EXISTS provider_id VARCHAR(255);
+
+UPDATE users SET provider_id = email WHERE provider_id IS NULL;
+
+ALTER TABLE users
+    ALTER COLUMN provider_id SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_auth_provider_provider_id ON users(auth_provider, provider_id);

--- a/services/api/models.go
+++ b/services/api/models.go
@@ -13,6 +13,8 @@ type User struct {
 	Email        string
 	PasswordHash string
 	DisplayName  string
+	AuthProvider string
+	ProviderID   string
 	CreatedAt    time.Time
 }
 
@@ -37,11 +39,11 @@ func CreateUser(db *sql.DB, email, passwordHash, displayName string) (*User, err
 	query := `
 		INSERT INTO users (id, email, password_hash, display_name, created_at)
 		VALUES ($1, $2, $3, $4, $5)
-		RETURNING id, email, password_hash, display_name, created_at
+		RETURNING id, email, password_hash, display_name, auth_provider, provider_id, created_at
 	`
 
 	err := db.QueryRow(query, user.ID, user.Email, user.PasswordHash, user.DisplayName, user.CreatedAt).
-		Scan(&user.ID, &user.Email, &user.PasswordHash, &user.DisplayName, &user.CreatedAt)
+		Scan(&user.ID, &user.Email, &user.PasswordHash, &user.DisplayName, &user.AuthProvider, &user.ProviderID, &user.CreatedAt)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create user: %w", err)
@@ -54,13 +56,13 @@ func CreateUser(db *sql.DB, email, passwordHash, displayName string) (*User, err
 func GetUserByEmail(db *sql.DB, email string) (*User, error) {
 	user := &User{}
 	query := `
-		SELECT id, email, password_hash, display_name, created_at
+		SELECT id, email, password_hash, display_name, auth_provider, provider_id, created_at
 		FROM users
 		WHERE email = $1
 	`
 
 	err := db.QueryRow(query, email).
-		Scan(&user.ID, &user.Email, &user.PasswordHash, &user.DisplayName, &user.CreatedAt)
+		Scan(&user.ID, &user.Email, &user.PasswordHash, &user.DisplayName, &user.AuthProvider, &user.ProviderID, &user.CreatedAt)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -76,19 +78,40 @@ func GetUserByEmail(db *sql.DB, email string) (*User, error) {
 func GetUserByID(db *sql.DB, id uuid.UUID) (*User, error) {
 	user := &User{}
 	query := `
-		SELECT id, email, password_hash, display_name, created_at
+		SELECT id, email, password_hash, display_name, auth_provider, provider_id, created_at
 		FROM users
 		WHERE id = $1
 	`
 
 	err := db.QueryRow(query, id).
-		Scan(&user.ID, &user.Email, &user.PasswordHash, &user.DisplayName, &user.CreatedAt)
+		Scan(&user.ID, &user.Email, &user.PasswordHash, &user.DisplayName, &user.AuthProvider, &user.ProviderID, &user.CreatedAt)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user by ID: %w", err)
+	}
+
+	return user, nil
+}
+
+// UpsertTelegramUser creates or updates the user linked to a Telegram account.
+func UpsertTelegramUser(db *sql.DB, telegramID int64, displayName string) (*User, error) {
+	user := &User{}
+	providerID := fmt.Sprintf("%d", telegramID)
+	query := `
+		INSERT INTO users (id, email, password_hash, display_name, auth_provider, provider_id, created_at)
+		VALUES ($1, $2, '', $3, 'telegram', $4, $5)
+		ON CONFLICT (auth_provider, provider_id)
+		DO UPDATE SET display_name = EXCLUDED.display_name
+		RETURNING id, email, password_hash, display_name, auth_provider, provider_id, created_at
+	`
+
+	err := db.QueryRow(query, uuid.New(), "telegram:"+providerID, displayName, providerID, time.Now()).
+		Scan(&user.ID, &user.Email, &user.PasswordHash, &user.DisplayName, &user.AuthProvider, &user.ProviderID, &user.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to upsert Telegram user: %w", err)
 	}
 
 	return user, nil

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -123,7 +123,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -444,7 +443,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -493,9 +491,31 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1451,7 +1471,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1498,7 +1519,6 @@
       "integrity": "sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1509,7 +1529,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1520,7 +1539,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1570,7 +1588,6 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -1914,7 +1931,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1955,6 +1971,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1965,6 +1982,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2058,7 +2076,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2238,7 +2255,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.352",
@@ -2310,7 +2328,6 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3184,6 +3201,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3385,7 +3403,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3485,6 +3502,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3509,7 +3527,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3519,7 +3536,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3532,7 +3548,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-router": {
       "version": "7.15.0",
@@ -3881,7 +3898,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3978,7 +3994,6 @@
       "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4275,7 +4290,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { MemoryRouter } from 'react-router'
 import { afterEach, expect, test, vi } from 'vitest'
 import App from './App'
-import { postGuest, postLogin, postRegister } from './api/auth'
+import { postGuest, postLogin, postRegister, postTelegramAuth } from './api/auth'
 
 vi.mock('./api/auth', () => ({
   AuthApiError: class AuthApiError extends Error {
@@ -18,6 +18,7 @@ vi.mock('./api/auth', () => ({
   postGuest: vi.fn(),
   postLogin: vi.fn(),
   postRegister: vi.fn(),
+  postTelegramAuth: vi.fn(),
 }))
 
 afterEach(() => {
@@ -139,6 +140,22 @@ test('sign-in submit calls login auth and navigates to lobby', async () => {
   })
   expect(localStorage.getItem('seven_spade_auth_token')).toBe('user-token')
   expect(localStorage.getItem('seven_spade_refresh_token')).toBe('refresh-token')
+})
+
+test('telegram auth callback posts payload and navigates to lobby', async () => {
+  vi.mocked(postTelegramAuth).mockResolvedValue({ jwt: 'telegram-token', refresh_token: 'telegram-refresh-token' })
+  renderRoute('/auth')
+
+  window.onTelegramAuth?.({ id: 123, first_name: 'Ada', auth_date: 1710000000, hash: 'valid-hash' })
+
+  await waitFor(() => {
+    expect(postTelegramAuth).toHaveBeenCalledWith({ id: 123, first_name: 'Ada', auth_date: 1710000000, hash: 'valid-hash' })
+  })
+  await waitFor(() => {
+    expect(screen.getByRole('heading', { name: /Game lobby/i })).toBeInTheDocument()
+  })
+  expect(localStorage.getItem('seven_spade_auth_token')).toBe('telegram-token')
+  expect(localStorage.getItem('seven_spade_refresh_token')).toBe('telegram-refresh-token')
 })
 
 test('register route renders create-account form with terms and auth link', () => {

--- a/web/src/api/auth.test.ts
+++ b/web/src/api/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { postRegister, postLogin, postRefresh, AuthApiError } from './auth'
+import { postRegister, postLogin, postRefresh, postTelegramAuth, AuthApiError } from './auth'
 
 describe('postRegister', () => {
   beforeEach(() => {
@@ -155,5 +155,58 @@ describe('postRefresh', () => {
     )
 
     await expect(postRefresh('invalid-token')).rejects.toThrow(AuthApiError)
+  })
+})
+
+describe('postTelegramAuth', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should post Telegram widget payload', async () => {
+    const mockResponse = {
+      jwt: 'telegram-jwt-token',
+      refresh_token: 'telegram-refresh-token',
+    }
+    const payload = {
+      id: 123,
+      first_name: 'Ada',
+      auth_date: 1710000000,
+      hash: 'valid-hash',
+    }
+
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(mockResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+
+    const result = await postTelegramAuth(payload)
+
+    expect(result).toEqual(mockResponse)
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:8080/auth/telegram',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+    )
+  })
+
+  it('should throw AuthApiError for invalid Telegram payload', async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Invalid or expired Telegram payload' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+
+    await expect(postTelegramAuth({ id: 123, auth_date: 1710000000, hash: 'bad-hash' })).rejects.toThrow(AuthApiError)
   })
 })

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -13,6 +13,16 @@ export interface RefreshResponse {
   jwt: string;
 }
 
+export interface TelegramAuthPayload {
+  id: number;
+  first_name?: string;
+  last_name?: string;
+  username?: string;
+  photo_url?: string;
+  auth_date: number;
+  hash: string;
+}
+
 export interface AuthError {
   error: string;
 }
@@ -185,4 +195,32 @@ export async function postRefresh(refreshToken: string): Promise<RefreshResponse
   }
 
   return response.json() as Promise<RefreshResponse>;
+}
+
+export async function postTelegramAuth(payload: TelegramAuthPayload): Promise<AuthResponse> {
+  const response = await fetch(`${API_URL}/auth/telegram`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    let errorMessage = `Request failed with status ${response.status}`;
+    let errorDetails: AuthError | undefined;
+
+    try {
+      errorDetails = await response.json() as AuthError;
+      if (errorDetails.error) {
+        errorMessage = errorDetails.error;
+      }
+    } catch {
+      // If parsing fails, use the default error message
+    }
+
+    throw new AuthApiError(errorMessage, response.status, errorDetails);
+  }
+
+  return response.json() as Promise<AuthResponse>;
 }

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -43,6 +43,22 @@ export class AuthApiError extends Error {
   }
 }
 
+async function parseAuthResponseError(response: Response): Promise<AuthApiError> {
+  let errorMessage = `Request failed with status ${response.status}`;
+  let errorDetails: AuthError | undefined;
+
+  try {
+    errorDetails = await response.json() as AuthError;
+    if (errorDetails.error) {
+      errorMessage = errorDetails.error;
+    }
+  } catch {
+    // Use the default status-based message when the API does not return JSON.
+  }
+
+  return new AuthApiError(errorMessage, response.status, errorDetails);
+}
+
 /**
  * Call POST /guest to get a JWT for a guest user
  * @param displayName - The display name for the guest user (1-50 characters)
@@ -67,19 +83,7 @@ export async function postGuest(displayName: string): Promise<GuestAuthResponse>
   });
 
   if (!response.ok) {
-    let errorMessage = `Request failed with status ${response.status}`;
-    let errorDetails: AuthError | undefined;
-
-    try {
-      errorDetails = await response.json() as AuthError;
-      if (errorDetails.error) {
-        errorMessage = errorDetails.error;
-      }
-    } catch {
-      // If parsing fails, use the default error message
-    }
-
-    throw new AuthApiError(errorMessage, response.status, errorDetails);
+    throw await parseAuthResponseError(response);
   }
 
   return response.json() as Promise<GuestAuthResponse>;
@@ -107,19 +111,7 @@ export async function postRegister(
   });
 
   if (!response.ok) {
-    let errorMessage = `Request failed with status ${response.status}`;
-    let errorDetails: AuthError | undefined;
-
-    try {
-      errorDetails = await response.json() as AuthError;
-      if (errorDetails.error) {
-        errorMessage = errorDetails.error;
-      }
-    } catch {
-      // If parsing fails, use the default error message
-    }
-
-    throw new AuthApiError(errorMessage, response.status, errorDetails);
+    throw await parseAuthResponseError(response);
   }
 
   return response.json() as Promise<AuthResponse>;
@@ -145,19 +137,7 @@ export async function postLogin(
   });
 
   if (!response.ok) {
-    let errorMessage = `Request failed with status ${response.status}`;
-    let errorDetails: AuthError | undefined;
-
-    try {
-      errorDetails = await response.json() as AuthError;
-      if (errorDetails.error) {
-        errorMessage = errorDetails.error;
-      }
-    } catch {
-      // If parsing fails, use the default error message
-    }
-
-    throw new AuthApiError(errorMessage, response.status, errorDetails);
+    throw await parseAuthResponseError(response);
   }
 
   return response.json() as Promise<AuthResponse>;
@@ -179,19 +159,7 @@ export async function postRefresh(refreshToken: string): Promise<RefreshResponse
   });
 
   if (!response.ok) {
-    let errorMessage = `Request failed with status ${response.status}`;
-    let errorDetails: AuthError | undefined;
-
-    try {
-      errorDetails = await response.json() as AuthError;
-      if (errorDetails.error) {
-        errorMessage = errorDetails.error;
-      }
-    } catch {
-      // If parsing fails, use the default error message
-    }
-
-    throw new AuthApiError(errorMessage, response.status, errorDetails);
+    throw await parseAuthResponseError(response);
   }
 
   return response.json() as Promise<RefreshResponse>;
@@ -207,19 +175,7 @@ export async function postTelegramAuth(payload: TelegramAuthPayload): Promise<Au
   });
 
   if (!response.ok) {
-    let errorMessage = `Request failed with status ${response.status}`;
-    let errorDetails: AuthError | undefined;
-
-    try {
-      errorDetails = await response.json() as AuthError;
-      if (errorDetails.error) {
-        errorMessage = errorDetails.error;
-      }
-    } catch {
-      // If parsing fails, use the default error message
-    }
-
-    throw new AuthApiError(errorMessage, response.status, errorDetails);
+    throw await parseAuthResponseError(response);
   }
 
   return response.json() as Promise<AuthResponse>;

--- a/web/src/pages/AuthPage.tsx
+++ b/web/src/pages/AuthPage.tsx
@@ -1,8 +1,14 @@
-import { type FormEvent, useState } from 'react'
+import { type FormEvent, useEffect, useRef, useState } from 'react'
 import { useNavigate, Link } from 'react-router'
 import { Button } from '../components/Button'
-import { postGuest, postLogin, AuthApiError } from '../api/auth'
+import { postGuest, postLogin, postTelegramAuth, AuthApiError, type TelegramAuthPayload } from '../api/auth'
 import { useAuth } from '../hooks/useAuth'
+
+declare global {
+  interface Window {
+    onTelegramAuth?: (payload: TelegramAuthPayload) => void
+  }
+}
 
 export function AuthPage() {
   const navigate = useNavigate()
@@ -14,6 +20,9 @@ export function AuthPage() {
   const [password, setPassword] = useState('')
   const [loginIsLoading, setLoginIsLoading] = useState(false)
   const [loginError, setLoginError] = useState<string | null>(null)
+  const [telegramError, setTelegramError] = useState<string | null>(null)
+  const telegramContainerRef = useRef<HTMLDivElement | null>(null)
+  const telegramBotName = import.meta.env.VITE_TELEGRAM_BOT_NAME as string | undefined
 
   const getErrorMessage = (err: unknown) => {
     if (err instanceof AuthApiError) {
@@ -58,6 +67,45 @@ export function AuthPage() {
       setLoginIsLoading(false)
     }
   }
+
+  useEffect(() => {
+    window.onTelegramAuth = async (payload: TelegramAuthPayload) => {
+      setTelegramError(null)
+      try {
+        const response = await postTelegramAuth(payload)
+        login(response.jwt, response.refresh_token)
+        navigate('/lobby')
+      } catch (err) {
+        setTelegramError(getErrorMessage(err))
+      }
+    }
+
+    return () => {
+      delete window.onTelegramAuth
+    }
+  }, [login, navigate])
+
+  useEffect(() => {
+    const container = telegramContainerRef.current
+    if (!container || !telegramBotName) {
+      return
+    }
+
+    container.innerHTML = ''
+    const script = document.createElement('script')
+    script.async = true
+    script.src = 'https://telegram.org/js/telegram-widget.js?22'
+    script.setAttribute('data-telegram-login', telegramBotName)
+    script.setAttribute('data-size', 'large')
+    script.setAttribute('data-userpic', 'false')
+    script.setAttribute('data-radius', '8')
+    script.setAttribute('data-onauth', 'window.onTelegramAuth(user)')
+    container.appendChild(script)
+
+    return () => {
+      container.innerHTML = ''
+    }
+  }, [telegramBotName])
 
   return (
     <section className="grid min-h-svh bg-spade-bg md:grid-cols-[minmax(0,7fr)_minmax(420px,5fr)]">
@@ -177,6 +225,25 @@ export function AuthPage() {
               <Link to="/register" className="font-medium text-spade-gold hover:text-spade-gold-light">
                 Register here
               </Link>
+            </div>
+
+            <div className="mt-5 border-t border-spade-cream/10 pt-5">
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <span className="font-mono text-xs uppercase tracking-[0.12em] text-spade-gray-3">OAuth</span>
+                <span className="status-badge status-checking">Telegram</span>
+              </div>
+              <div className="rounded-spade-md border border-spade-cream/10 bg-spade-bg/70 p-3 text-center">
+                {telegramBotName ? (
+                  <div ref={telegramContainerRef} className="flex min-h-10 justify-center" aria-label="Telegram Login Widget" />
+                ) : (
+                  <p className="text-sm text-spade-gray-2">Telegram login is waiting for bot configuration.</p>
+                )}
+              </div>
+              {telegramError ? (
+                <div className="mt-3 rounded-spade-md border border-spade-red/50 bg-spade-red/10 px-3 py-2 text-sm text-[#ffb4ab]">
+                  {telegramError}
+                </div>
+              ) : null}
             </div>
           </div>
         </div>


### PR DESCRIPTION
Closes #8

## Summary
Implemented Telegram Login Widget authentication end-to-end: the frontend receives the widget payload and the API verifies it, upserts the Telegram user, and returns JWT plus refresh token.

## Changes
- Added `POST /auth/telegram` with Telegram HMAC verification and 24-hour payload expiry.
- Added provider identity columns and a migration for Telegram-backed users.
- Added frontend auth API support and Seven Spade-styled Telegram widget area.
- Added backend and frontend tests for valid and tampered Telegram auth payloads.

## Decisions
- Telegram is handled as the Login Widget flow, not OAuth2 redirects.
- API requires `TELEGRAM_BOT_TOKEN`; web widget renders when `VITE_TELEGRAM_BOT_NAME` is configured.
- Telegram users use synthetic `telegram:<id>` emails to fit existing user records while provider fields preserve the identity source.