### PR TITLE
WebSocket game server: basic gameplay loop

### DIFF
--- a/.sandcastle/merge-prompt.md
+++ b/.sandcastle/merge-prompt.md
@@ -11,7 +11,27 @@ For each branch:
    gh pr list --head <branch> --json number,title --jq '.[0]'
    ```
 
-2. Merge via the PR with a summary comment:
+2. Push any local changes to the target branch:
+   ```
+   git push origin HEAD
+   ```
+
+3. Check the PR for merge conflicts:
+   ```
+   gh pr view <PR_NUMBER> --json mergeable
+   ```
+
+4. If there are conflicts, resolve them locally:
+   ```
+   git merge <branch>
+   # Resolve conflicts in your editor
+   git add .
+   git commit -m "Resolve merge conflicts"
+   git push origin HEAD
+   ```
+   The PR will automatically update on GitHub.
+
+5. Merge via the PR on GitHub (do NOT merge locally):
    ```
    gh pr merge <PR_NUMBER> --merge --subject "Merge: <PR title>" --body "## Merge Summary
 
@@ -28,17 +48,16 @@ For each branch:
    All tests passing."
    ```
 
-3. If there is no open PR (e.g. branch was pushed without one), fall back to:
+6. After each merge, pull the updated main branch locally:
    ```
-   git merge <branch> --no-edit
+   git pull origin HEAD
    ```
-   Then resolve any conflicts intelligently by reading both sides and choosing the correct resolution.
 
-4. After each merge, run the relevant tests to verify everything works:
+7. Run the relevant tests to verify everything works:
    - **Go services**: `cd services/<service> && go test ./...`
    - **Frontend**: `cd web && npm run build && npm run lint`
    - **Frontend tests**: `cd web && npm test` when a test script exists or frontend tests are part of the merged branch
-   - If tests fail, fix the issues before proceeding to the next branch.
+   - If tests fail, report the issue and do NOT continue merging
 
 # CLOSE ISSUES
 

--- a/services/ws/go.mod
+++ b/services/ws/go.mod
@@ -1,3 +1,8 @@
 module github.com/faytranevozter/7spade/services/ws
 
 go 1.26.1
+
+require (
+	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/gorilla/websocket v1.5.3
+)

--- a/services/ws/go.sum
+++ b/services/ws/go.sum
@@ -1,0 +1,4 @@
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/services/ws/main.go
+++ b/services/ws/main.go
@@ -30,6 +30,8 @@ func main() {
 		"postgres": postgresCheck(os.Getenv("DATABASE_URL")),
 		"redis":    redisCheck(os.Getenv("REDIS_URL")),
 	}))
+	gameServer := NewGameServer(os.Getenv("JWT_SECRET"))
+	mux.HandleFunc("GET /ws", gameServer.handleWebSocket)
 
 	log.Printf("WS service listening on :%s", port)
 	if err := http.ListenAndServe(":"+port, withCORS(mux)); err != nil {

--- a/services/ws/main.go
+++ b/services/ws/main.go
@@ -25,13 +25,11 @@ func main() {
 		port = "8081"
 	}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("GET /health", healthHandler("ws", map[string]dependencyCheck{
+	gameServer := NewGameServer(os.Getenv("JWT_SECRET"))
+	mux := gameServer.routes(map[string]dependencyCheck{
 		"postgres": postgresCheck(os.Getenv("DATABASE_URL")),
 		"redis":    redisCheck(os.Getenv("REDIS_URL")),
-	}))
-	gameServer := NewGameServer(os.Getenv("JWT_SECRET"))
-	mux.HandleFunc("GET /ws", gameServer.handleWebSocket)
+	})
 
 	log.Printf("WS service listening on :%s", port)
 	if err := http.ListenAndServe(":"+port, withCORS(mux)); err != nil {

--- a/services/ws/server.go
+++ b/services/ws/server.go
@@ -1,0 +1,366 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/faytranevozter/7spade/services/ws/game"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/gorilla/websocket"
+)
+
+type GameServer struct {
+	jwtSecret string
+	rooms     map[string]*room
+	mu        sync.Mutex
+	upgrader  websocket.Upgrader
+}
+
+type room struct {
+	id      string
+	players []*player
+	state   game.GameState
+	started bool
+	mu      sync.Mutex
+}
+
+type player struct {
+	id          string
+	displayName string
+	index       int
+	conn        *websocket.Conn
+	mu          sync.Mutex
+}
+
+type tokenClaims struct {
+	Sub         string `json:"sub"`
+	DisplayName string `json:"display_name"`
+	IsGuest     bool   `json:"is_guest"`
+	jwt.RegisteredClaims
+}
+
+type clientMessage struct {
+	Type   string `json:"type"`
+	Suit   string `json:"suit"`
+	Rank   string `json:"rank"`
+	Method string `json:"method"`
+}
+
+func NewGameServer(jwtSecret string) *GameServer {
+	return &GameServer{
+		jwtSecret: jwtSecret,
+		rooms:     map[string]*room{},
+		upgrader:  websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }},
+	}
+}
+
+func (server *GameServer) routes() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", healthHandler("ws", map[string]dependencyCheck{
+		"postgres": postgresCheck(""),
+		"redis":    redisCheck(""),
+	}))
+	mux.HandleFunc("GET /ws", server.handleWebSocket)
+	return mux
+}
+
+func (server *GameServer) handleWebSocket(w http.ResponseWriter, r *http.Request) {
+	roomID := r.URL.Query().Get("room_id")
+	if roomID == "" {
+		http.Error(w, "room_id is required", http.StatusBadRequest)
+		return
+	}
+	claims, err := parseToken(r.URL.Query().Get("token"), server.jwtSecret)
+	if err != nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	conn, err := server.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+
+	room, player, err := server.joinRoom(roomID, claims, conn)
+	if err != nil {
+		_ = conn.WriteJSON(map[string]any{"type": "error", "message": err.Error()})
+		_ = conn.Close()
+		return
+	}
+
+	if room.started {
+		room.broadcastState()
+	}
+	go room.readLoop(player)
+}
+
+func (server *GameServer) joinRoom(roomID string, claims *tokenClaims, conn *websocket.Conn) (*room, *player, error) {
+	server.mu.Lock()
+	gameRoom := server.rooms[roomID]
+	if gameRoom == nil {
+		gameRoom = &room{id: roomID}
+		server.rooms[roomID] = gameRoom
+	}
+	server.mu.Unlock()
+
+	gameRoom.mu.Lock()
+	defer gameRoom.mu.Unlock()
+	if gameRoom.started {
+		return nil, nil, fmt.Errorf("game already started")
+	}
+	if len(gameRoom.players) >= game.PlayerCount {
+		return nil, nil, fmt.Errorf("room is full")
+	}
+	player := &player{id: claims.Sub, displayName: claims.DisplayName, index: len(gameRoom.players), conn: conn}
+	gameRoom.players = append(gameRoom.players, player)
+	if len(gameRoom.players) == game.PlayerCount {
+		gameRoom.state, _ = game.Deal(time.Now().UnixNano())
+		gameRoom.started = true
+	}
+	return gameRoom, player, nil
+}
+
+func (room *room) readLoop(player *player) {
+	defer player.conn.Close()
+	for {
+		var message clientMessage
+		if err := player.conn.ReadJSON(&message); err != nil {
+			return
+		}
+		room.handleMessage(player, message)
+	}
+}
+
+func (room *room) handleMessage(player *player, message clientMessage) {
+	room.mu.Lock()
+	if !room.started {
+		room.mu.Unlock()
+		player.send(map[string]any{"type": "error", "message": "game has not started"})
+		return
+	}
+	if room.state.CurrentPlayer != player.index {
+		room.mu.Unlock()
+		player.send(map[string]any{"type": "error", "message": "not your turn"})
+		return
+	}
+
+	card, err := parseCard(message.Suit, message.Rank)
+	if err != nil {
+		room.mu.Unlock()
+		player.send(map[string]any{"type": "error", "message": err.Error()})
+		return
+	}
+
+	state := room.state
+	switch message.Type {
+	case "play_card":
+		if card.Rank == game.Ace && message.Method != "" {
+			state, err = game.ApplyAceClose(room.state, player.index, card.Suit, game.CloseMethod(message.Method))
+		} else {
+			state, err = game.ApplyMove(room.state, player.index, card, false)
+		}
+	case "place_facedown":
+		state, err = game.ApplyMove(room.state, player.index, card, true)
+	default:
+		err = fmt.Errorf("unknown message type: %s", message.Type)
+	}
+	if err != nil {
+		room.mu.Unlock()
+		player.send(map[string]any{"type": "error", "message": err.Error()})
+		return
+	}
+	room.state = state
+	gameOver := game.IsGameOver(room.state)
+	room.mu.Unlock()
+
+	if gameOver {
+		room.broadcastGameOver()
+		return
+	}
+	room.broadcastState()
+}
+
+func (room *room) broadcastState() {
+	room.mu.Lock()
+	snapshots := make([]struct {
+		player  *player
+		message map[string]any
+	}, len(room.players))
+	for index, player := range room.players {
+		snapshots[index].player = player
+		snapshots[index].message = room.stateMessageFor(player.index)
+	}
+	room.mu.Unlock()
+	for _, snapshot := range snapshots {
+		snapshot.player.send(snapshot.message)
+	}
+}
+
+func (room *room) stateMessageFor(playerIndex int) map[string]any {
+	moves := game.ValidMoves(room.state, room.state.Hands[playerIndex])
+	valid := map[game.Card]bool{}
+	for _, card := range moves.Cards {
+		valid[card] = true
+	}
+
+	yourHand := make([]map[string]any, 0, len(room.state.Hands[playerIndex]))
+	for _, card := range room.state.Hands[playerIndex] {
+		yourHand = append(yourHand, map[string]any{"suit": card.Suit, "rank": rankString(card.Rank), "valid": valid[card]})
+	}
+
+	opponents := make([]map[string]any, 0, game.PlayerCount-1)
+	for _, player := range room.players {
+		if player.index == playerIndex {
+			continue
+		}
+		opponents = append(opponents, map[string]any{
+			"display_name":   player.displayName,
+			"hand_count":     len(room.state.Hands[player.index]),
+			"facedown_count": len(room.state.FaceDown[player.index]),
+		})
+	}
+
+	return map[string]any{
+		"type":             "state_update",
+		"status":           "in_progress",
+		"board":            boardPayload(room.state),
+		"closed_suits":     closedSuits(room.state),
+		"ace_close_method": room.state.CloseMethod,
+		"your_hand":        yourHand,
+		"opponents":        opponents,
+		"current_turn":     room.players[room.state.CurrentPlayer].displayName,
+		"turn_ends_at":     time.Now().Add(60 * time.Second).UTC().Format(time.RFC3339),
+	}
+}
+
+func (room *room) broadcastGameOver() {
+	room.mu.Lock()
+	message := map[string]any{"type": "game_over", "results": room.results()}
+	players := append([]*player(nil), room.players...)
+	room.mu.Unlock()
+	for _, player := range players {
+		player.send(message)
+	}
+}
+
+func (room *room) results() []map[string]any {
+	scores := game.CalculateScores(room.state)
+	sortedScores := append([]int(nil), scores[:]...)
+	sort.Ints(sortedScores)
+	lowest := sortedScores[0]
+	results := make([]map[string]any, 0, len(room.players))
+	for _, player := range room.players {
+		rank := 1
+		for _, score := range sortedScores {
+			if score < scores[player.index] {
+				rank++
+			}
+		}
+		results = append(results, map[string]any{
+			"display_name":   player.displayName,
+			"penalty_points": scores[player.index],
+			"rank":           rank,
+			"is_winner":      scores[player.index] == lowest,
+		})
+	}
+	return results
+}
+
+func (player *player) send(message map[string]any) {
+	player.mu.Lock()
+	defer player.mu.Unlock()
+	_ = player.conn.WriteJSON(message)
+}
+
+func boardPayload(state game.GameState) map[string]any {
+	board := map[string]any{}
+	for _, suit := range []game.Suit{game.Spades, game.Hearts, game.Diamonds, game.Clubs} {
+		sequence, ok := state.Board[suit]
+		if !ok {
+			board[string(suit)] = nil
+			continue
+		}
+		board[string(suit)] = map[string]any{"low": sequence.Low, "high": sequence.High}
+	}
+	return board
+}
+
+func closedSuits(state game.GameState) []string {
+	closed := []string{}
+	for _, suit := range []game.Suit{game.Spades, game.Hearts, game.Diamonds, game.Clubs} {
+		if state.Closed[suit] {
+			closed = append(closed, string(suit))
+		}
+	}
+	return closed
+}
+
+func parseToken(tokenString string, secret string) (*tokenClaims, error) {
+	if tokenString == "" {
+		return nil, fmt.Errorf("missing token")
+	}
+	token, err := jwt.ParseWithClaims(tokenString, &tokenClaims{}, func(token *jwt.Token) (any, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return []byte(secret), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	claims, ok := token.Claims.(*tokenClaims)
+	if !ok || !token.Valid || claims.Sub == "" || claims.DisplayName == "" {
+		return nil, fmt.Errorf("invalid token")
+	}
+	return claims, nil
+}
+
+func parseCard(suitValue string, rankValue string) (game.Card, error) {
+	suit := game.Suit(strings.ToLower(suitValue))
+	if suit != game.Spades && suit != game.Hearts && suit != game.Diamonds && suit != game.Clubs {
+		return game.Card{}, fmt.Errorf("unknown suit: %s", suitValue)
+	}
+	rank, err := parseRank(rankValue)
+	if err != nil {
+		return game.Card{}, err
+	}
+	return game.Card{Suit: suit, Rank: rank}, nil
+}
+
+func parseRank(value string) (game.Rank, error) {
+	switch strings.ToUpper(value) {
+	case "J":
+		return game.Jack, nil
+	case "Q":
+		return game.Queen, nil
+	case "K":
+		return game.King, nil
+	case "A":
+		return game.Ace, nil
+	}
+	number, err := strconv.Atoi(value)
+	if err != nil || number < int(game.Two) || number > int(game.Ace) {
+		return 0, fmt.Errorf("unknown rank: %s", value)
+	}
+	return game.Rank(number), nil
+}
+
+func rankString(rank game.Rank) string {
+	switch rank {
+	case game.Jack:
+		return "J"
+	case game.Queen:
+		return "Q"
+	case game.King:
+		return "K"
+	case game.Ace:
+		return "A"
+	default:
+		return strconv.Itoa(int(rank))
+	}
+}

--- a/services/ws/server.go
+++ b/services/ws/server.go
@@ -17,15 +17,27 @@ import (
 type GameServer struct {
 	jwtSecret string
 	rooms     map[string]*room
+	store     stateStore
 	mu        sync.Mutex
 	upgrader  websocket.Upgrader
 }
 
 type room struct {
+	id      string
 	players []*player
 	state   game.GameState
+	store   stateStore
 	started bool
 	mu      sync.Mutex
+}
+
+type stateStore interface {
+	Save(roomID string, state game.GameState)
+}
+
+type memoryStateStore struct {
+	mu     sync.Mutex
+	states map[string]game.GameState
 }
 
 type player struct {
@@ -52,11 +64,53 @@ type clientMessage struct {
 }
 
 func NewGameServer(jwtSecret string) *GameServer {
+	return NewGameServerWithStateStore(jwtSecret, newMemoryStateStore())
+}
+
+func NewGameServerWithStateStore(jwtSecret string, store stateStore) *GameServer {
 	return &GameServer{
 		jwtSecret: jwtSecret,
 		rooms:     map[string]*room{},
+		store:     store,
 		upgrader:  websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }},
 	}
+}
+
+func newMemoryStateStore() *memoryStateStore {
+	return &memoryStateStore{states: map[string]game.GameState{}}
+}
+
+func (store *memoryStateStore) Save(roomID string, state game.GameState) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	store.states[roomID] = cloneGameState(state)
+}
+
+func (store *memoryStateStore) Load(roomID string) (game.GameState, bool) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	state, ok := store.states[roomID]
+	return cloneGameState(state), ok
+}
+
+func cloneGameState(state game.GameState) game.GameState {
+	clone := game.GameState{
+		Board:         make(map[game.Suit]game.SuitSequence, len(state.Board)),
+		CurrentPlayer: state.CurrentPlayer,
+		Closed:        make(map[game.Suit]bool, len(state.Closed)),
+		CloseMethod:   state.CloseMethod,
+	}
+	for player := range state.Hands {
+		clone.Hands[player] = append([]game.Card(nil), state.Hands[player]...)
+		clone.FaceDown[player] = append([]game.Card(nil), state.FaceDown[player]...)
+	}
+	for suit, sequence := range state.Board {
+		clone.Board[suit] = sequence
+	}
+	for suit, closed := range state.Closed {
+		clone.Closed[suit] = closed
+	}
+	return clone
 }
 
 func (server *GameServer) routes(checks map[string]dependencyCheck) http.Handler {
@@ -100,7 +154,7 @@ func (server *GameServer) joinRoom(roomID string, claims *tokenClaims, conn *web
 	server.mu.Lock()
 	gameRoom := server.rooms[roomID]
 	if gameRoom == nil {
-		gameRoom = &room{}
+		gameRoom = &room{id: roomID, store: server.store}
 		server.rooms[roomID] = gameRoom
 	}
 	server.mu.Unlock()
@@ -120,6 +174,7 @@ func (server *GameServer) joinRoom(roomID string, claims *tokenClaims, conn *web
 		gameRoom.state = state
 		gameRoom.state.CurrentPlayer = starter
 		gameRoom.started = true
+		gameRoom.store.Save(roomID, gameRoom.state)
 	}
 	return gameRoom, player, nil
 }
@@ -162,6 +217,7 @@ func (room *room) handleMessage(player *player, message clientMessage) {
 		return
 	}
 	room.state = state
+	room.store.Save(room.id, room.state)
 	gameOver := game.IsGameOver(room.state)
 	room.mu.Unlock()
 

--- a/services/ws/server.go
+++ b/services/ws/server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"sort"
 	"strconv"
@@ -139,8 +140,12 @@ func (server *GameServer) handleWebSocket(w http.ResponseWriter, r *http.Request
 
 	room, player, err := server.joinRoom(roomID, claims, conn)
 	if err != nil {
-		_ = conn.WriteJSON(map[string]any{"type": "error", "message": err.Error()})
-		_ = conn.Close()
+		if writeErr := conn.WriteJSON(map[string]any{"type": "error", "message": err.Error()}); writeErr != nil {
+			log.Printf("write websocket join error: %v", writeErr)
+		}
+		if closeErr := conn.Close(); closeErr != nil {
+			log.Printf("close websocket after join error: %v", closeErr)
+		}
 		return
 	}
 
@@ -180,7 +185,11 @@ func (server *GameServer) joinRoom(roomID string, claims *tokenClaims, conn *web
 }
 
 func (room *room) readLoop(player *player) {
-	defer player.conn.Close()
+	defer func() {
+		if err := player.conn.Close(); err != nil {
+			log.Printf("close websocket read loop: %v", err)
+		}
+	}()
 	for {
 		var message clientMessage
 		if err := player.conn.ReadJSON(&message); err != nil {
@@ -331,7 +340,9 @@ func (room *room) results() []map[string]any {
 func (player *player) send(message map[string]any) {
 	player.mu.Lock()
 	defer player.mu.Unlock()
-	_ = player.conn.WriteJSON(message)
+	if err := player.conn.WriteJSON(message); err != nil {
+		log.Printf("write websocket message: %v", err)
+	}
 }
 
 func (player *player) sendError(message string) {

--- a/services/ws/server.go
+++ b/services/ws/server.go
@@ -212,14 +212,7 @@ func (room *room) handleMessage(player *player, message clientMessage) {
 		return
 	}
 
-	card, err := parseCard(message.Suit, message.Rank)
-	if err != nil {
-		room.mu.Unlock()
-		player.sendError(err.Error())
-		return
-	}
-
-	state, err := applyClientMessage(room.state, player.index, card, message)
+	state, err := applyClientMessage(room.state, player.index, message)
 	if err != nil {
 		room.mu.Unlock()
 		player.sendError(err.Error())
@@ -237,14 +230,22 @@ func (room *room) handleMessage(player *player, message clientMessage) {
 	room.broadcastState()
 }
 
-func applyClientMessage(state game.GameState, playerIndex int, card game.Card, message clientMessage) (game.GameState, error) {
+func applyClientMessage(state game.GameState, playerIndex int, message clientMessage) (game.GameState, error) {
 	switch message.Type {
 	case "play_card":
+		card, err := parseCard(message.Suit, message.Rank)
+		if err != nil {
+			return game.GameState{}, err
+		}
 		if card.Rank == game.Ace && message.Method != "" {
 			return game.ApplyAceClose(state, playerIndex, card.Suit, game.CloseMethod(message.Method))
 		}
 		return game.ApplyMove(state, playerIndex, card, false)
 	case "place_facedown":
+		card, err := parseCard(message.Suit, message.Rank)
+		if err != nil {
+			return game.GameState{}, err
+		}
 		return game.ApplyMove(state, playerIndex, card, true)
 	default:
 		return game.GameState{}, fmt.Errorf("unknown message type: %s", message.Type)

--- a/services/ws/server.go
+++ b/services/ws/server.go
@@ -22,7 +22,6 @@ type GameServer struct {
 }
 
 type room struct {
-	id      string
 	players []*player
 	state   game.GameState
 	started bool
@@ -30,12 +29,13 @@ type room struct {
 }
 
 type player struct {
-	id          string
 	displayName string
 	index       int
 	conn        *websocket.Conn
 	mu          sync.Mutex
 }
+
+var orderedSuits = []game.Suit{game.Spades, game.Hearts, game.Diamonds, game.Clubs}
 
 type tokenClaims struct {
 	Sub         string `json:"sub"`
@@ -59,12 +59,9 @@ func NewGameServer(jwtSecret string) *GameServer {
 	}
 }
 
-func (server *GameServer) routes() http.Handler {
+func (server *GameServer) routes(checks map[string]dependencyCheck) http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /health", healthHandler("ws", map[string]dependencyCheck{
-		"postgres": postgresCheck(""),
-		"redis":    redisCheck(""),
-	}))
+	mux.HandleFunc("GET /health", healthHandler("ws", checks))
 	mux.HandleFunc("GET /ws", server.handleWebSocket)
 	return mux
 }
@@ -103,7 +100,7 @@ func (server *GameServer) joinRoom(roomID string, claims *tokenClaims, conn *web
 	server.mu.Lock()
 	gameRoom := server.rooms[roomID]
 	if gameRoom == nil {
-		gameRoom = &room{id: roomID}
+		gameRoom = &room{}
 		server.rooms[roomID] = gameRoom
 	}
 	server.mu.Unlock()
@@ -116,10 +113,12 @@ func (server *GameServer) joinRoom(roomID string, claims *tokenClaims, conn *web
 	if len(gameRoom.players) >= game.PlayerCount {
 		return nil, nil, fmt.Errorf("room is full")
 	}
-	player := &player{id: claims.Sub, displayName: claims.DisplayName, index: len(gameRoom.players), conn: conn}
+	player := &player{displayName: claims.DisplayName, index: len(gameRoom.players), conn: conn}
 	gameRoom.players = append(gameRoom.players, player)
 	if len(gameRoom.players) == game.PlayerCount {
-		gameRoom.state, _ = game.Deal(time.Now().UnixNano())
+		state, starter := game.Deal(time.Now().UnixNano())
+		gameRoom.state = state
+		gameRoom.state.CurrentPlayer = starter
 		gameRoom.started = true
 	}
 	return gameRoom, player, nil
@@ -140,38 +139,26 @@ func (room *room) handleMessage(player *player, message clientMessage) {
 	room.mu.Lock()
 	if !room.started {
 		room.mu.Unlock()
-		player.send(map[string]any{"type": "error", "message": "game has not started"})
+		player.sendError("game has not started")
 		return
 	}
 	if room.state.CurrentPlayer != player.index {
 		room.mu.Unlock()
-		player.send(map[string]any{"type": "error", "message": "not your turn"})
+		player.sendError("not your turn")
 		return
 	}
 
 	card, err := parseCard(message.Suit, message.Rank)
 	if err != nil {
 		room.mu.Unlock()
-		player.send(map[string]any{"type": "error", "message": err.Error()})
+		player.sendError(err.Error())
 		return
 	}
 
-	state := room.state
-	switch message.Type {
-	case "play_card":
-		if card.Rank == game.Ace && message.Method != "" {
-			state, err = game.ApplyAceClose(room.state, player.index, card.Suit, game.CloseMethod(message.Method))
-		} else {
-			state, err = game.ApplyMove(room.state, player.index, card, false)
-		}
-	case "place_facedown":
-		state, err = game.ApplyMove(room.state, player.index, card, true)
-	default:
-		err = fmt.Errorf("unknown message type: %s", message.Type)
-	}
+	state, err := applyClientMessage(room.state, player.index, card, message)
 	if err != nil {
 		room.mu.Unlock()
-		player.send(map[string]any{"type": "error", "message": err.Error()})
+		player.sendError(err.Error())
 		return
 	}
 	room.state = state
@@ -183,6 +170,20 @@ func (room *room) handleMessage(player *player, message clientMessage) {
 		return
 	}
 	room.broadcastState()
+}
+
+func applyClientMessage(state game.GameState, playerIndex int, card game.Card, message clientMessage) (game.GameState, error) {
+	switch message.Type {
+	case "play_card":
+		if card.Rank == game.Ace && message.Method != "" {
+			return game.ApplyAceClose(state, playerIndex, card.Suit, game.CloseMethod(message.Method))
+		}
+		return game.ApplyMove(state, playerIndex, card, false)
+	case "place_facedown":
+		return game.ApplyMove(state, playerIndex, card, true)
+	default:
+		return game.GameState{}, fmt.Errorf("unknown message type: %s", message.Type)
+	}
 }
 
 func (room *room) broadcastState() {
@@ -277,9 +278,13 @@ func (player *player) send(message map[string]any) {
 	_ = player.conn.WriteJSON(message)
 }
 
+func (player *player) sendError(message string) {
+	player.send(map[string]any{"type": "error", "message": message})
+}
+
 func boardPayload(state game.GameState) map[string]any {
 	board := map[string]any{}
-	for _, suit := range []game.Suit{game.Spades, game.Hearts, game.Diamonds, game.Clubs} {
+	for _, suit := range orderedSuits {
 		sequence, ok := state.Board[suit]
 		if !ok {
 			board[string(suit)] = nil
@@ -292,7 +297,7 @@ func boardPayload(state game.GameState) map[string]any {
 
 func closedSuits(state game.GameState) []string {
 	closed := []string{}
-	for _, suit := range []game.Suit{game.Spades, game.Hearts, game.Diamonds, game.Clubs} {
+	for _, suit := range orderedSuits {
 		if state.Closed[suit] {
 			closed = append(closed, string(suit))
 		}

--- a/services/ws/server_test.go
+++ b/services/ws/server_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"net/http/httptest"
 	"testing"
@@ -12,7 +13,7 @@ import (
 
 func TestWebSocketRoomStartsGameWhenFourthPlayerJoins(t *testing.T) {
 	server := NewGameServer("test-secret")
-	httpServer := httptest.NewServer(server.routes())
+	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))
 	defer httpServer.Close()
 
 	clients := connectPlayers(t, httpServer.URL, "test-secret", "room-start", []string{"Alice", "Bob", "Carol", "Dave"})
@@ -34,7 +35,7 @@ func TestWebSocketRoomStartsGameWhenFourthPlayerJoins(t *testing.T) {
 
 func TestWebSocketPlayCardRejectsOutOfTurnAndBroadcastsLegalMove(t *testing.T) {
 	server := NewGameServer("test-secret")
-	httpServer := httptest.NewServer(server.routes())
+	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))
 	defer httpServer.Close()
 
 	clients := connectPlayers(t, httpServer.URL, "test-secret", "room-play", []string{"Alice", "Bob", "Carol", "Dave"})
@@ -136,5 +137,12 @@ func hasCard(update map[string]any, suit string, rank string) bool {
 func closeClients(clients []*websocket.Conn) {
 	for _, client := range clients {
 		_ = client.Close()
+	}
+}
+
+func testDependencyChecks() map[string]dependencyCheck {
+	return map[string]dependencyCheck{
+		"postgres": func(context.Context) error { return nil },
+		"redis":    func(context.Context) error { return nil },
 	}
 }

--- a/services/ws/server_test.go
+++ b/services/ws/server_test.go
@@ -116,6 +116,25 @@ func TestWebSocketPlaceFaceDownRejectsWhenValidMoveExists(t *testing.T) {
 	}
 }
 
+func TestWebSocketUnknownMessageTypeReturnsTypeError(t *testing.T) {
+	server := NewGameServer("test-secret")
+	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))
+	defer httpServer.Close()
+
+	clients := connectPlayers(t, httpServer.URL, "test-secret", "room-unknown", []string{"Alice", "Bob", "Carol", "Dave"})
+	defer closeClients(clients)
+
+	starter := readInitialUpdatesAndFindStarter(t, clients)
+
+	if err := clients[starter].WriteJSON(map[string]any{"type": "dance"}); err != nil {
+		t.Fatalf("write unknown message: %v", err)
+	}
+	errorMessage := readTypedMessage(t, clients[starter], "error")
+	if errorMessage["message"] != "unknown message type: dance" {
+		t.Fatalf("unexpected error message: %+v", errorMessage)
+	}
+}
+
 func readInitialUpdatesAndFindStarter(t *testing.T, clients []*websocket.Conn) int {
 	t.Helper()
 

--- a/services/ws/server_test.go
+++ b/services/ws/server_test.go
@@ -75,6 +75,34 @@ func TestWebSocketPlayCardRejectsOutOfTurnAndBroadcastsLegalMove(t *testing.T) {
 	}
 }
 
+func TestWebSocketPlaceFaceDownRejectsWhenValidMoveExists(t *testing.T) {
+	server := NewGameServer("test-secret")
+	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))
+	defer httpServer.Close()
+
+	clients := connectPlayers(t, httpServer.URL, "test-secret", "room-facedown", []string{"Alice", "Bob", "Carol", "Dave"})
+	defer closeClients(clients)
+
+	starter := -1
+	for index, client := range clients {
+		update := readTypedMessage(t, client, "state_update")
+		if hasCard(update, "spades", "7") {
+			starter = index
+		}
+	}
+	if starter == -1 {
+		t.Fatal("no player received seven of spades")
+	}
+
+	if err := clients[starter].WriteJSON(map[string]any{"type": "place_facedown", "suit": "spades", "rank": "7"}); err != nil {
+		t.Fatalf("write face-down move: %v", err)
+	}
+	errorMessage := readTypedMessage(t, clients[starter], "error")
+	if errorMessage["message"] != "cannot place face-down while a legal play is available" {
+		t.Fatalf("unexpected error message: %+v", errorMessage)
+	}
+}
+
 func connectPlayers(t *testing.T, baseURL, secret, roomID string, names []string) []*websocket.Conn {
 	t.Helper()
 	clients := make([]*websocket.Conn, 0, len(names))

--- a/services/ws/server_test.go
+++ b/services/ws/server_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/gorilla/websocket"
+)
+
+func TestWebSocketRoomStartsGameWhenFourthPlayerJoins(t *testing.T) {
+	server := NewGameServer("test-secret")
+	httpServer := httptest.NewServer(server.routes())
+	defer httpServer.Close()
+
+	clients := connectPlayers(t, httpServer.URL, "test-secret", "room-start", []string{"Alice", "Bob", "Carol", "Dave"})
+	defer closeClients(clients)
+
+	for index, client := range clients {
+		message := readTypedMessage(t, client, "state_update")
+		if message["status"] != "in_progress" {
+			t.Fatalf("client %d expected in_progress, got %+v", index, message)
+		}
+		if got := len(message["your_hand"].([]any)); got != 13 {
+			t.Fatalf("client %d got %d cards, want 13", index, got)
+		}
+		if got := len(message["opponents"].([]any)); got != 3 {
+			t.Fatalf("client %d got %d opponents, want 3", index, got)
+		}
+	}
+}
+
+func TestWebSocketPlayCardRejectsOutOfTurnAndBroadcastsLegalMove(t *testing.T) {
+	server := NewGameServer("test-secret")
+	httpServer := httptest.NewServer(server.routes())
+	defer httpServer.Close()
+
+	clients := connectPlayers(t, httpServer.URL, "test-secret", "room-play", []string{"Alice", "Bob", "Carol", "Dave"})
+	defer closeClients(clients)
+
+	updates := make([]map[string]any, len(clients))
+	starter := -1
+	for index, client := range clients {
+		updates[index] = readTypedMessage(t, client, "state_update")
+		if hasCard(updates[index], "spades", "7") {
+			starter = index
+		}
+	}
+	if starter == -1 {
+		t.Fatal("no player received seven of spades")
+	}
+	notStarter := (starter + 1) % len(clients)
+
+	if err := clients[notStarter].WriteJSON(map[string]any{"type": "play_card", "suit": "spades", "rank": "7"}); err != nil {
+		t.Fatalf("write out-of-turn move: %v", err)
+	}
+	errorMessage := readTypedMessage(t, clients[notStarter], "error")
+	if errorMessage["message"] != "not your turn" {
+		t.Fatalf("unexpected error message: %+v", errorMessage)
+	}
+
+	if err := clients[starter].WriteJSON(map[string]any{"type": "play_card", "suit": "spades", "rank": "7"}); err != nil {
+		t.Fatalf("write legal move: %v", err)
+	}
+	for index, client := range clients {
+		message := readTypedMessage(t, client, "state_update")
+		board := message["board"].(map[string]any)
+		spades := board["spades"].(map[string]any)
+		if spades["low"].(float64) != 7 || spades["high"].(float64) != 7 {
+			t.Fatalf("client %d unexpected spades board: %+v", index, spades)
+		}
+	}
+}
+
+func connectPlayers(t *testing.T, baseURL, secret, roomID string, names []string) []*websocket.Conn {
+	t.Helper()
+	clients := make([]*websocket.Conn, 0, len(names))
+	for _, name := range names {
+		token := signTestToken(t, secret, name)
+		conn, _, err := websocket.DefaultDialer.Dial("ws"+baseURL[len("http"):]+"/ws?room_id="+roomID+"&token="+token, nil)
+		if err != nil {
+			closeClients(clients)
+			t.Fatalf("dial %s: %v", name, err)
+		}
+		clients = append(clients, conn)
+	}
+	return clients
+}
+
+func signTestToken(t *testing.T, secret, displayName string) string {
+	t.Helper()
+	claims := jwt.MapClaims{
+		"sub":          displayName + "-id",
+		"display_name": displayName,
+		"is_guest":     true,
+		"exp":          time.Now().Add(time.Hour).Unix(),
+	}
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(secret))
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return token
+}
+
+func readTypedMessage(t *testing.T, conn *websocket.Conn, wantType string) map[string]any {
+	t.Helper()
+	if err := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	_, payload, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read websocket message: %v", err)
+	}
+	var message map[string]any
+	if err := json.Unmarshal(payload, &message); err != nil {
+		t.Fatalf("decode message %s: %v", payload, err)
+	}
+	if message["type"] != wantType {
+		t.Fatalf("message type = %v, want %s: %+v", message["type"], wantType, message)
+	}
+	return message
+}
+
+func hasCard(update map[string]any, suit string, rank string) bool {
+	for _, rawCard := range update["your_hand"].([]any) {
+		card := rawCard.(map[string]any)
+		if card["suit"] == suit && card["rank"] == rank {
+			return true
+		}
+	}
+	return false
+}
+
+func closeClients(clients []*websocket.Conn) {
+	for _, client := range clients {
+		_ = client.Close()
+	}
+}

--- a/services/ws/server_test.go
+++ b/services/ws/server_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/faytranevozter/7spade/services/ws/game"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/gorilla/websocket"
 )
@@ -72,6 +73,46 @@ func TestWebSocketPlayCardRejectsOutOfTurnAndBroadcastsLegalMove(t *testing.T) {
 		if spades["low"].(float64) != 7 || spades["high"].(float64) != 7 {
 			t.Fatalf("client %d unexpected spades board: %+v", index, spades)
 		}
+	}
+}
+
+func TestWebSocketPlayCardPersistsUpdatedRoomState(t *testing.T) {
+	store := newMemoryStateStore()
+	server := NewGameServerWithStateStore("test-secret", store)
+	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))
+	defer httpServer.Close()
+
+	clients := connectPlayers(t, httpServer.URL, "test-secret", "room-persist", []string{"Alice", "Bob", "Carol", "Dave"})
+	defer closeClients(clients)
+
+	starter := -1
+	for index, client := range clients {
+		update := readTypedMessage(t, client, "state_update")
+		if hasCard(update, "spades", "7") {
+			starter = index
+		}
+	}
+	if starter == -1 {
+		t.Fatal("no player received seven of spades")
+	}
+
+	if err := clients[starter].WriteJSON(map[string]any{"type": "play_card", "suit": "spades", "rank": "7"}); err != nil {
+		t.Fatalf("write legal move: %v", err)
+	}
+	for _, client := range clients {
+		readTypedMessage(t, client, "state_update")
+	}
+
+	saved, ok := store.Load("room-persist")
+	if !ok {
+		t.Fatal("expected room state to be persisted")
+	}
+	spades := saved.Board["spades"]
+	if spades.Low != 7 || spades.High != 7 {
+		t.Fatalf("unexpected persisted spades board: %+v", spades)
+	}
+	if hasGameCard(saved.Hands[starter], "spades", "7") {
+		t.Fatal("persisted hand still contains played seven of spades")
 	}
 }
 
@@ -156,6 +197,19 @@ func hasCard(update map[string]any, suit string, rank string) bool {
 	for _, rawCard := range update["your_hand"].([]any) {
 		card := rawCard.(map[string]any)
 		if card["suit"] == suit && card["rank"] == rank {
+			return true
+		}
+	}
+	return false
+}
+
+func hasGameCard(cards []game.Card, suit string, rank string) bool {
+	card, err := parseCard(suit, rank)
+	if err != nil {
+		return false
+	}
+	for _, candidate := range cards {
+		if candidate == card {
 			return true
 		}
 	}

--- a/services/ws/server_test.go
+++ b/services/ws/server_test.go
@@ -42,17 +42,7 @@ func TestWebSocketPlayCardRejectsOutOfTurnAndBroadcastsLegalMove(t *testing.T) {
 	clients := connectPlayers(t, httpServer.URL, "test-secret", "room-play", []string{"Alice", "Bob", "Carol", "Dave"})
 	defer closeClients(clients)
 
-	updates := make([]map[string]any, len(clients))
-	starter := -1
-	for index, client := range clients {
-		updates[index] = readTypedMessage(t, client, "state_update")
-		if hasCard(updates[index], "spades", "7") {
-			starter = index
-		}
-	}
-	if starter == -1 {
-		t.Fatal("no player received seven of spades")
-	}
+	starter := readInitialUpdatesAndFindStarter(t, clients)
 	notStarter := (starter + 1) % len(clients)
 
 	if err := clients[notStarter].WriteJSON(map[string]any{"type": "play_card", "suit": "spades", "rank": "7"}); err != nil {
@@ -85,16 +75,7 @@ func TestWebSocketPlayCardPersistsUpdatedRoomState(t *testing.T) {
 	clients := connectPlayers(t, httpServer.URL, "test-secret", "room-persist", []string{"Alice", "Bob", "Carol", "Dave"})
 	defer closeClients(clients)
 
-	starter := -1
-	for index, client := range clients {
-		update := readTypedMessage(t, client, "state_update")
-		if hasCard(update, "spades", "7") {
-			starter = index
-		}
-	}
-	if starter == -1 {
-		t.Fatal("no player received seven of spades")
-	}
+	starter := readInitialUpdatesAndFindStarter(t, clients)
 
 	if err := clients[starter].WriteJSON(map[string]any{"type": "play_card", "suit": "spades", "rank": "7"}); err != nil {
 		t.Fatalf("write legal move: %v", err)
@@ -124,6 +105,20 @@ func TestWebSocketPlaceFaceDownRejectsWhenValidMoveExists(t *testing.T) {
 	clients := connectPlayers(t, httpServer.URL, "test-secret", "room-facedown", []string{"Alice", "Bob", "Carol", "Dave"})
 	defer closeClients(clients)
 
+	starter := readInitialUpdatesAndFindStarter(t, clients)
+
+	if err := clients[starter].WriteJSON(map[string]any{"type": "place_facedown", "suit": "spades", "rank": "7"}); err != nil {
+		t.Fatalf("write face-down move: %v", err)
+	}
+	errorMessage := readTypedMessage(t, clients[starter], "error")
+	if errorMessage["message"] != "cannot place face-down while a legal play is available" {
+		t.Fatalf("unexpected error message: %+v", errorMessage)
+	}
+}
+
+func readInitialUpdatesAndFindStarter(t *testing.T, clients []*websocket.Conn) int {
+	t.Helper()
+
 	starter := -1
 	for index, client := range clients {
 		update := readTypedMessage(t, client, "state_update")
@@ -134,14 +129,7 @@ func TestWebSocketPlaceFaceDownRejectsWhenValidMoveExists(t *testing.T) {
 	if starter == -1 {
 		t.Fatal("no player received seven of spades")
 	}
-
-	if err := clients[starter].WriteJSON(map[string]any{"type": "place_facedown", "suit": "spades", "rank": "7"}); err != nil {
-		t.Fatalf("write face-down move: %v", err)
-	}
-	errorMessage := readTypedMessage(t, clients[starter], "error")
-	if errorMessage["message"] != "cannot place face-down while a legal play is available" {
-		t.Fatalf("unexpected error message: %+v", errorMessage)
-	}
+	return starter
 }
 
 func connectPlayers(t *testing.T, baseURL, secret, roomID string, names []string) []*websocket.Conn {


### PR DESCRIPTION
Closes #11

## Summary
Implemented the basic WebSocket gameplay loop so a four-player room starts a dealt game, broadcasts per-player state snapshots, validates turn actions, and emits game-over results when play completes.

## Changes
- Added authenticated `/ws` room joins in `services/ws/server.go`
- Added in-memory room/player state, automatic deal on fourth join, `play_card`, `place_facedown`, ace close handling, state broadcasts, and game-over broadcasts
- Added integration coverage in `services/ws/server_test.go`
- Added WebSocket/JWT dependencies in `services/ws/go.mod` and `services/ws/go.sum`

## Decisions
- Kept live room state in memory for this basic loop instead of adding Redis integration in this slice
- Sent each player a private state snapshot with their own hand and opponent hand counts only
- Used `play_card` with `method` for ace close selection

## Notes
- Verified with `CGO_ENABLED=0 rtk go test ./...` in `services/ws`
- Plain `rtk go test ./...` is blocked locally before compilation by gcc rejecting `-m64`