### PR TITLE
React game board: live gameplay

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -110,7 +110,7 @@ test('renders a single dynamic game route', () => {
 
   expect(screen.getByRole('heading', { name: /Live game table/i })).toBeInTheDocument()
   expect(screen.getByRole('region', { name: /Seven Spade game board/i })).toBeInTheDocument()
-  expect(screen.getByRole('button', { name: /Play card/i })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /Reconnect/i })).toBeInTheDocument()
 })
 
 test('temporary buttons navigate through the hardcoded flow', async () => {
@@ -125,12 +125,7 @@ test('temporary buttons navigate through the hardcoded flow', async () => {
     expect(screen.getByRole('heading', { name: /Live game table/i })).toBeInTheDocument()
   })
 
-  fireEvent.click(screen.getByRole('button', { name: /Play card/i }))
-  await waitFor(() => {
-    expect(screen.getByRole('heading', { name: /Results and rematch/i })).toBeInTheDocument()
-  })
-
-  fireEvent.click(screen.getByRole('button', { name: /View history/i }))
+  fireEvent.click(screen.getByRole('button', { name: /History/i }))
   await waitFor(() => {
     expect(screen.getByRole('heading', { name: /Game history/i })).toBeInTheDocument()
   })
@@ -364,6 +359,7 @@ test('OAuth callback stores tokens and redirects to lobby', async () => {
 })
 
 test('OAuth callback shows error message on failure', async () => {
+  localStorage.clear()
   render(
     <MemoryRouter initialEntries={[{ pathname: '/auth/callback', hash: '#provider=google&error=access_denied' }]}>
       <App />
@@ -375,5 +371,4 @@ test('OAuth callback shows error message on failure', async () => {
   })
   expect(screen.getByText(/cancelled the sign-in/i)).toBeInTheDocument()
   expect(localStorage.getItem('seven_spade_auth_token')).toBeNull()
-})
 })

--- a/web/src/components/CardFace.tsx
+++ b/web/src/components/CardFace.tsx
@@ -7,6 +7,7 @@ type CardFaceProps = {
   onDark?: boolean
   interactive?: boolean
   onClick?: () => void
+  ariaLabel?: string
 }
 
 const sizeClasses = {
@@ -15,12 +16,12 @@ const sizeClasses = {
   board: 'aspect-[48/68] size-full',
 }
 
-export function CardFace({ card, size = 'md', onDark = true, interactive = true, onClick }: CardFaceProps) {
+export function CardFace({ card, size = 'md', onDark = true, interactive = true, onClick, ariaLabel }: CardFaceProps) {
   const tone = suitColorClass[card.suit]
   const label = `${card.rank} of ${card.suit}`
   const selected = card.selected ? '-translate-y-3 ring-2 ring-spade-gold' : ''
   const playable = card.playable ? 'ring-2 ring-spade-green-light' : ''
-  const dimmed = card.dimmed ? 'opacity-75 saturate-75' : ''
+  const dimmed = card.dimmed ? 'opacity-45 saturate-75' : ''
   const shadow = onDark && interactive ? 'shadow-spade-card hover:shadow-spade-card-hover' : 'shadow-spade-card'
   const interaction = interactive
     ? 'cursor-pointer hover:-translate-y-1.5'
@@ -31,7 +32,7 @@ export function CardFace({ card, size = 'md', onDark = true, interactive = true,
       type="button"
       tabIndex={interactive ? 0 : -1}
       onClick={onClick}
-      aria-label={card.playable ? `Play ${label}` : label}
+      aria-label={ariaLabel ?? (card.playable ? `Play ${label}` : label)}
       data-playable={card.playable ? 'true' : 'false'}
       data-selected={card.selected ? 'true' : 'false'}
       className={`relative shrink-0 rounded-[10px] bg-spade-white text-left ${sizeClasses[size]} ${selected} ${playable} ${dimmed} ${shadow} ${interaction} transition duration-150 ease-spade-spring`}

--- a/web/src/hooks/useGameSocket.ts
+++ b/web/src/hooks/useGameSocket.ts
@@ -61,6 +61,7 @@ export type GameSocketState = {
   players: Player[]
   toasts: Toast[]
   isMyTurn: boolean
+  currentTurnName: string | null
   turnEndsAt: string | null
   rematchVotes: number
   rematchTotal: number
@@ -78,6 +79,7 @@ export function useGameSocket(roomId: string | undefined, token: string | null):
   const [players, setPlayers] = useState<Player[]>([])
   const [toasts, setToasts] = useState<Toast[]>([])
   const [isMyTurn, setIsMyTurn] = useState(false)
+  const [currentTurnName, setCurrentTurnName] = useState<string | null>(null)
   const [turnEndsAt, setTurnEndsAt] = useState<string | null>(null)
   const [rematchVotes, setRematchVotes] = useState(0)
   const [rematchTotal, setRematchTotal] = useState(4)
@@ -106,6 +108,7 @@ export function useGameSocket(roomId: string | undefined, token: string | null):
         setPlayers,
         setToasts,
         setIsMyTurn,
+        setCurrentTurnName,
         setTurnEndsAt,
         setRematchVotes,
         setRematchTotal,
@@ -167,6 +170,7 @@ export function useGameSocket(roomId: string | undefined, token: string | null):
     players,
     toasts,
     isMyTurn,
+    currentTurnName,
     turnEndsAt,
     rematchVotes,
     rematchTotal,
@@ -182,6 +186,7 @@ export function useGameSocket(roomId: string | undefined, token: string | null):
     players,
     toasts,
     isMyTurn,
+    currentTurnName,
     turnEndsAt,
     rematchVotes,
     rematchTotal,
@@ -201,6 +206,7 @@ function handleMessage(
     setPlayers: Dispatch<SetStateAction<Player[]>>
     setToasts: Dispatch<SetStateAction<Toast[]>>
     setIsMyTurn: (isMyTurn: boolean) => void
+    setCurrentTurnName: (name: string | null) => void
     setTurnEndsAt: (turnEndsAt: string | null) => void
     setRematchVotes: (votes: number) => void
     setRematchTotal: (total: number) => void
@@ -222,7 +228,9 @@ function handleMessage(
     setters.setBoardRows(buildBoardRows(message.board, message.closed_suits ?? []))
     setters.setHand(message.your_hand.map(toCard))
     setters.setPlayers(buildPlayers(message))
-    setters.setIsMyTurn(Boolean(message.your_hand.some((card) => card.valid)))
+    const isMyTurn = Boolean(message.your_hand.some((card) => card.valid))
+    setters.setIsMyTurn(isMyTurn)
+    setters.setCurrentTurnName(isMyTurn ? 'You' : message.current_turn)
     setters.setTurnEndsAt(message.turn_ends_at ?? null)
     setters.setGameOver(false)
     return

--- a/web/src/pages/GamePage.test.tsx
+++ b/web/src/pages/GamePage.test.tsx
@@ -1,0 +1,113 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+import { GamePage } from './GamePage'
+import { useGameSocket, type GameSocketState } from '../hooks/useGameSocket'
+
+vi.mock('../hooks/useGameSocket', () => ({
+  useGameSocket: vi.fn(),
+}))
+
+const sendPlayCard = vi.fn()
+const sendFaceDown = vi.fn()
+
+const liveState: GameSocketState = {
+  status: 'open',
+  boardRows: [
+    { suit: 'Spades', cards: [null, null, null, null, null, '6', '7', '8', null, null, null, null, null] },
+    { suit: 'Hearts', cards: [null, null, null, null, null, null, '7', null, null, null, null, null, null], closed: true },
+    { suit: 'Diamonds', cards: [null, null, null, null, null, null, null, null, null, null, null, null, null] },
+    { suit: 'Clubs', cards: [null, null, null, null, null, null, '7', '8', '9', null, null, null, null] },
+  ],
+  hand: [
+    { rank: '5', suit: 'Spades' },
+    { rank: '9', suit: 'Spades', playable: true },
+    { rank: 'A', suit: 'Hearts' },
+  ],
+  players: [
+    { name: 'You', initials: 'YU', cardsLeft: 3, faceDownCount: 0, tone: 'green', active: true },
+    { name: 'Budi', initials: 'BU', cardsLeft: 8, faceDownCount: 2, tone: 'gold' },
+    { name: 'Santi', initials: 'SA', cardsLeft: 5, faceDownCount: 1, tone: 'dark' },
+  ],
+  currentTurnName: 'You',
+  toasts: [],
+  isMyTurn: true,
+  turnEndsAt: '2026-05-16T12:00:18Z',
+  rematchVotes: 0,
+  rematchTotal: 4,
+  gameOver: false,
+  sendPlayCard,
+  sendFaceDown,
+  sendRematchVote: vi.fn(),
+  reconnect: vi.fn(),
+}
+
+beforeEach(() => {
+  localStorage.setItem('seven_spade_auth_token', 'test-token')
+  vi.mocked(useGameSocket).mockReturnValue(liveState)
+})
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+  vi.clearAllMocks()
+})
+
+function renderGame() {
+  return render(
+    <MemoryRouter initialEntries={['/game/room-1']}>
+      <Routes>
+        <Route path="/game/:roomId" element={<GamePage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+test('renders live board sequences, closed suits, turn, and opponent counts', () => {
+  renderGame()
+
+  expect(screen.getByRole('region', { name: /Seven Spade game board/i })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: '6 of Spades' })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: '7 of Spades' })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: '8 of Spades' })).toBeInTheDocument()
+  expect(screen.getByLabelText('Hearts suit sequence')).toHaveTextContent('Closed')
+  expect(screen.getByText('Turn: You')).toBeInTheDocument()
+  expect(screen.getByText('Budi')).toBeInTheDocument()
+  expect(screen.getByText('8 cards')).toBeInTheDocument()
+  expect(screen.getByText('2 face-down')).toBeInTheDocument()
+})
+
+test('only valid hand cards are highlighted and clickable on your turn', () => {
+  renderGame()
+
+  const playable = screen.getByRole('button', { name: 'Play 9 of Spades' })
+  const invalid = screen.getByRole('button', { name: '5 of Spades' })
+
+  expect(playable).toHaveAttribute('data-playable', 'true')
+  expect(invalid).toHaveAttribute('data-playable', 'false')
+  expect(invalid).toHaveClass('opacity-45')
+
+  fireEvent.click(invalid)
+  expect(sendPlayCard).not.toHaveBeenCalled()
+
+  fireEvent.click(playable)
+  expect(sendPlayCard).toHaveBeenCalledWith({ rank: '9', suit: 'Spades', playable: true })
+})
+
+test('shows face-down selection modal when your turn has no valid moves', () => {
+  vi.mocked(useGameSocket).mockReturnValue({
+    ...liveState,
+    hand: liveState.hand.map((card) => ({ rank: card.rank, suit: card.suit })),
+    isMyTurn: true,
+    currentTurnName: 'You',
+  })
+
+  renderGame()
+
+  expect(screen.getByRole('dialog', { name: /Place a face-down card/i })).toBeInTheDocument()
+
+  fireEvent.click(screen.getByRole('button', { name: /Place A of Hearts face down/i }))
+
+  expect(sendFaceDown).toHaveBeenCalledWith({ rank: 'A', suit: 'Hearts' })
+})

--- a/web/src/pages/GamePage.tsx
+++ b/web/src/pages/GamePage.tsx
@@ -1,117 +1,139 @@
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router'
 import { Badge } from '../components/Badge'
 import { Button } from '../components/Button'
+import { CardFace } from '../components/CardFace'
 import { CardStack } from '../components/CardStack'
 import { GameBoard } from '../components/GameBoard'
+import { Modal } from '../components/Modal'
 import { PlayerAvatar } from '../components/PlayerAvatar'
 import { SectionPanel } from '../components/SectionPanel'
 import { ToastStack } from '../components/ToastStack'
-import type { BoardRow, Card, Player, Toast } from '../types'
+import { useAuth } from '../hooks/useAuth'
+import { useGameSocket } from '../hooks/useGameSocket'
+import type { Card } from '../types'
 
-const players: Player[] = [
-  { name: 'Fahrur', initials: 'FA', cardsLeft: 8, faceDownCount: 2, tone: 'green', active: true },
-  { name: 'Budi', initials: 'BU', cardsLeft: 11, faceDownCount: 0, tone: 'gold' },
-  { name: 'Santi', initials: 'SA', cardsLeft: 6, faceDownCount: 3, tone: 'dark' },
-  { name: 'Rini', initials: 'RI', cardsLeft: 0, faceDownCount: 1, tone: 'red', winner: true },
-]
-
-const hand: Card[] = [
-  { rank: '2', suit: 'Hearts' },
-  { rank: '3', suit: 'Clubs' },
-  { rank: '4', suit: 'Hearts' },
-  { rank: '5', suit: 'Diamonds' },
-  { rank: '6', suit: 'Spades', playable: true },
-  { rank: '7', suit: 'Clubs' },
-  { rank: '8', suit: 'Diamonds' },
-  { rank: '9', suit: 'Hearts' },
-  { rank: '10', suit: 'Spades' },
-  { rank: 'J', suit: 'Clubs' },
-  { rank: 'Q', suit: 'Diamonds' },
-  { rank: 'K', suit: 'Hearts' },
-  { rank: 'A', suit: 'Spades' },
-]
-
-const boardRows: BoardRow[] = [
-  { suit: 'Hearts', cards: ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'] },
-  { suit: 'Spades', cards: [null, null, null, null, null, '7', '8', null, null, null, null, null, null] },
-  { suit: 'Diamonds', cards: [null, null, null, null, null, '7', '8', '9', '10', null, null, null, null] },
-  { suit: 'Clubs', cards: [null, null, null, null, null, null, null, null, null, null, null, null, null], closed: true },
-]
-
-const toasts: Toast[] = [
-  { tone: 'success', title: 'Card played', body: '8 Hearts placed on the Hearts row' },
-  { tone: 'warn', title: '10 seconds left', body: 'Make your move or prepare a penalty card' },
-  { tone: 'info', title: "Budi's turn", body: 'Waiting for another player to move' },
-]
+const connectionTone = {
+  idle: 'waiting',
+  connecting: 'waiting',
+  open: 'playing',
+  closed: 'danger',
+  error: 'danger',
+} as const
 
 export function GamePage() {
   const { roomId } = useParams()
   const navigate = useNavigate()
-  const [selectedCard, setSelectedCard] = useState<Card | null>(hand.find((card) => card.playable) ?? null)
+  const { token } = useAuth()
+  const game = useGameSocket(roomId, token)
+  const hasValidMoves = game.hand.some((card) => card.playable)
+  const showFaceDownModal = game.isMyTurn && game.hand.length > 0 && !hasValidMoves
 
-  const visibleHand = useMemo(() => hand.map((card) => ({
+  const visibleHand = useMemo(() => game.hand.map((card) => ({
     ...card,
-    selected: selectedCard?.rank === card.rank && selectedCard.suit === card.suit,
-  })), [selectedCard])
+    dimmed: game.isMyTurn && hasValidMoves && !card.playable,
+  })), [game.hand, game.isMyTurn, hasValidMoves])
+
+  const playCard = (card: Card) => {
+    if (!game.isMyTurn || !card.playable) {
+      return
+    }
+
+    game.sendPlayCard({ rank: card.rank, suit: card.suit, playable: card.playable })
+  }
+
+  const statusLabel = game.status === 'open' ? 'Connected' : game.status
+  const turnLabel = game.currentTurnName ? `Turn: ${game.currentTurnName}` : 'Waiting for turn'
 
   return (
     <SectionPanel
       title="Live game table"
-      eyebrow={roomId ? `Room ${roomId}` : 'Room preview'}
+      eyebrow={roomId ? `Room ${roomId}` : 'Room'}
       action={
         <div className="flex flex-wrap gap-2">
-          <Badge tone="playing">Your turn</Badge>
-          <Badge tone="playing">Connected</Badge>
-          <span className="rounded-spade-pill border border-spade-gold-light/40 bg-spade-gold/15 px-3 py-1 font-mono text-xs text-spade-gold-light">
-            00:18
-          </span>
+          <Badge tone={game.isMyTurn ? 'playing' : 'waiting'}>{game.isMyTurn ? 'Your turn' : turnLabel}</Badge>
+          <Badge tone={connectionTone[game.status]}>{statusLabel}</Badge>
+          {game.turnEndsAt ? (
+            <span className="rounded-spade-pill border border-spade-gold-light/40 bg-spade-gold/15 px-3 py-1 font-mono text-xs text-spade-gold-light">
+              {formatTurnClock(game.turnEndsAt)}
+            </span>
+          ) : null}
         </div>
       }
     >
       <div className="grid gap-4">
         <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
-          {players.map((player) => (
+          {game.players.map((player) => (
             <PlayerAvatar key={player.name} player={player} />
           ))}
         </div>
 
-        <GameBoard rows={boardRows} />
+        <GameBoard rows={game.boardRows} />
 
         <CardStack
           cards={visibleHand}
-          interactive
-          onCardClick={setSelectedCard}
-          meta={`${hand.length} cards`}
+          interactive={game.isMyTurn && hasValidMoves}
+          onCardClick={playCard}
+          meta={`${game.hand.length} cards · ${turnLabel}`}
         />
 
         <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_340px]">
           <div className="rounded-spade-lg border border-spade-cream/10 bg-[#2b302d] p-4">
             <div className="mb-3 flex items-center justify-between gap-3">
               <h3 className="text-lg font-medium">Table state</h3>
-              <Badge tone="playing">Act now</Badge>
+              <Badge tone={game.isMyTurn ? 'playing' : 'waiting'}>{turnLabel}</Badge>
             </div>
             <p className="text-sm text-spade-gray-2">
-              {selectedCard ? `${selectedCard.rank} of ${selectedCard.suit} selected` : 'Select a card to preview the move.'}
+              {game.isMyTurn
+                ? hasValidMoves ? 'Play a highlighted card to extend an open suit.' : 'No valid moves. Choose a penalty card to place face down.'
+                : 'Waiting for the active player to move.'}
             </p>
           </div>
 
           <div className="rounded-spade-lg border border-spade-cream/10 bg-spade-bg/50 p-4">
             <div className="mb-3 flex items-center justify-between">
               <h3 className="text-lg font-medium">Actions</h3>
-              <Badge tone="waiting">Preview</Badge>
+              <Badge tone={game.gameOver ? 'winner' : 'waiting'}>{game.gameOver ? 'Round over' : 'Live'}</Badge>
             </div>
             <div className="grid grid-cols-2 gap-2">
-              <Button onClick={() => navigate(`/results/${roomId ?? 'XKQP7'}`)}>Play card</Button>
-              <Button variant="secondary" onClick={() => navigate(`/results/${roomId ?? 'XKQP7'}`)}>Face down</Button>
+              <Button variant="secondary" onClick={game.reconnect}>Reconnect</Button>
               <Button variant="ghost" onClick={() => navigate('/history')}>History</Button>
               <Button variant="danger" onClick={() => navigate('/lobby')}>Leave room</Button>
             </div>
           </div>
         </div>
 
-        <ToastStack toasts={toasts} />
+        <ToastStack toasts={game.toasts} />
+
+        {showFaceDownModal ? (
+          <Modal
+            title="Place a face-down card"
+            eyebrow="No valid moves"
+            description="Select any card from your hand. It will be added to your face-down penalty pile for this round."
+          >
+            <div className="grid grid-cols-3 gap-3 sm:grid-cols-4">
+              {game.hand.map((card) => (
+                <CardFace
+                  key={`${card.rank}-${card.suit}`}
+                  card={card}
+                  ariaLabel={`Place ${card.rank} of ${card.suit} face down`}
+                  onClick={() => game.sendFaceDown(card)}
+                />
+              ))}
+            </div>
+          </Modal>
+        ) : null}
       </div>
     </SectionPanel>
   )
+}
+
+function formatTurnClock(turnEndsAt: string): string {
+  const endsAt = Date.parse(turnEndsAt)
+  if (Number.isNaN(endsAt)) {
+    return 'Live'
+  }
+
+  const seconds = Math.max(0, Math.ceil((endsAt - Date.now()) / 1000))
+  return `00:${String(seconds).padStart(2, '0')}`
 }


### PR DESCRIPTION
Closes #12

## Summary
Implemented the live React game board so gameplay renders from WebSocket state and player actions emit gameplay messages instead of using preview data.

## Changes
- Wired `GamePage` to `useGameSocket` and auth token state.
- Rendered live board rows, turn status, opponent card counts, hand highlights, and connection state.
- Added valid-card `play_card` handling and no-valid-moves face-down selection modal for `place_facedown`.
- Added focused component tests for live board sequences, valid card highlighting, and face-down modal behavior.

## Decisions
- Kept `GameBoard` presentation reusable and handled gameplay-specific action gating in `GamePage`.
- Exposed `currentTurnName` from the socket hook so the UI can name the active player.