### PR TITLE
Turn timer + auto-play

### DIFF
--- a/services/ws/game/bot.go
+++ b/services/ws/game/bot.go
@@ -1,0 +1,18 @@
+package game
+
+type BotMove struct {
+	Card     Card
+	FaceDown bool
+}
+
+func PickMove(state GameState, playerHand []Card) (BotMove, bool) {
+	if len(playerHand) == 0 {
+		return BotMove{}, false
+	}
+
+	moves := ValidMoves(state, playerHand)
+	if len(moves.Cards) > 0 {
+		return BotMove{Card: moves.Cards[0]}, true
+	}
+	return BotMove{Card: playerHand[0], FaceDown: true}, true
+}

--- a/services/ws/game/bot_test.go
+++ b/services/ws/game/bot_test.go
@@ -1,0 +1,63 @@
+package game
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPickMoveReturnsFirstValidCard(t *testing.T) {
+	state := NewGameState()
+	state.Board[Spades] = SuitSequence{Low: Six, High: Eight}
+	hand := []Card{
+		{Suit: Hearts, Rank: Nine},
+		{Suit: Spades, Rank: Five},
+		{Suit: Spades, Rank: Nine},
+	}
+
+	move, ok := PickMove(state, hand)
+
+	if !ok {
+		t.Fatal("expected a bot move")
+	}
+	if move.Card != (Card{Suit: Spades, Rank: Five}) {
+		t.Fatalf("picked %+v, want first valid card", move.Card)
+	}
+	if move.FaceDown {
+		t.Fatal("expected playable card, got face-down move")
+	}
+}
+
+func TestPickMoveReturnsFirstCardFaceDownWhenNoValidMovesExist(t *testing.T) {
+	state := NewGameState()
+	state.Board[Spades] = SuitSequence{Low: Six, High: Eight}
+	hand := []Card{
+		{Suit: Hearts, Rank: Nine},
+		{Suit: Clubs, Rank: Three},
+	}
+
+	move, ok := PickMove(state, hand)
+
+	if !ok {
+		t.Fatal("expected a bot move")
+	}
+	if move.Card != hand[0] || !move.FaceDown {
+		t.Fatalf("picked %+v faceDown=%t, want first card face-down", move.Card, move.FaceDown)
+	}
+}
+
+func TestPickMoveIsDeterministic(t *testing.T) {
+	state := NewGameState()
+	state.Board[Spades] = SuitSequence{Low: Six, High: Eight}
+	hand := []Card{
+		{Suit: Hearts, Rank: Seven},
+		{Suit: Spades, Rank: Five},
+		{Suit: Spades, Rank: Nine},
+	}
+
+	first, firstOK := PickMove(state, hand)
+	second, secondOK := PickMove(state, hand)
+
+	if firstOK != secondOK || !reflect.DeepEqual(first, second) {
+		t.Fatalf("moves differ: first=%+v ok=%t second=%+v ok=%t", first, firstOK, second, secondOK)
+	}
+}

--- a/services/ws/server.go
+++ b/services/ws/server.go
@@ -16,20 +16,25 @@ import (
 )
 
 type GameServer struct {
-	jwtSecret string
-	rooms     map[string]*room
-	store     stateStore
-	mu        sync.Mutex
-	upgrader  websocket.Upgrader
+	jwtSecret         string
+	rooms             map[string]*room
+	store             stateStore
+	turnTimerDuration time.Duration
+	mu                sync.Mutex
+	upgrader          websocket.Upgrader
 }
 
 type room struct {
-	id      string
-	players []*player
-	state   game.GameState
-	store   stateStore
-	started bool
-	mu      sync.Mutex
+	id                string
+	players           []*player
+	state             game.GameState
+	store             stateStore
+	started           bool
+	turnTimerDuration time.Duration
+	turnExpiresAt     time.Time
+	turnTimer         *time.Timer
+	turnTimerToken    int
+	mu                sync.Mutex
 }
 
 type stateStore interface {
@@ -77,11 +82,16 @@ func NewGameServer(jwtSecret string) *GameServer {
 }
 
 func NewGameServerWithStateStore(jwtSecret string, store stateStore) *GameServer {
+	return NewGameServerWithOptions(jwtSecret, store, 60*time.Second)
+}
+
+func NewGameServerWithOptions(jwtSecret string, store stateStore, turnTimerDuration time.Duration) *GameServer {
 	return &GameServer{
-		jwtSecret: jwtSecret,
-		rooms:     map[string]*room{},
-		store:     store,
-		upgrader:  websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }},
+		jwtSecret:         jwtSecret,
+		rooms:             map[string]*room{},
+		store:             store,
+		turnTimerDuration: turnTimerDuration,
+		upgrader:          websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }},
 	}
 }
 
@@ -167,7 +177,7 @@ func (server *GameServer) joinRoom(roomID string, claims *tokenClaims, conn *web
 	server.mu.Lock()
 	gameRoom := server.rooms[roomID]
 	if gameRoom == nil {
-		gameRoom = &room{id: roomID, store: server.store}
+		gameRoom = &room{id: roomID, store: server.store, turnTimerDuration: server.turnTimerDuration}
 		server.rooms[roomID] = gameRoom
 	}
 	server.mu.Unlock()
@@ -188,6 +198,7 @@ func (server *GameServer) joinRoom(roomID string, claims *tokenClaims, conn *web
 		gameRoom.state.CurrentPlayer = starter
 		gameRoom.started = true
 		gameRoom.store.Save(roomID, gameRoom.state)
+		gameRoom.startTurnTimerLocked()
 	}
 	return gameRoom, player, nil
 }
@@ -229,6 +240,54 @@ func (room *room) handleMessage(player *player, message clientMessage) {
 	room.state = state
 	room.store.Save(room.id, room.state)
 	gameOver := game.IsGameOver(room.state)
+	if !gameOver {
+		room.startTurnTimerLocked()
+	}
+	room.mu.Unlock()
+
+	if gameOver {
+		room.broadcastGameOver()
+		return
+	}
+	room.broadcastState()
+}
+
+func (room *room) startTurnTimerLocked() {
+	if room.turnTimer != nil {
+		room.turnTimer.Stop()
+	}
+	room.turnExpiresAt = time.Now().Add(room.turnTimerDuration).UTC()
+	room.turnTimerToken++
+	token := room.turnTimerToken
+	room.turnTimer = time.AfterFunc(room.turnTimerDuration, func() {
+		room.handleTurnTimerExpired(token)
+	})
+}
+
+func (room *room) handleTurnTimerExpired(token int) {
+	room.mu.Lock()
+	if !room.started || token != room.turnTimerToken || game.IsGameOver(room.state) {
+		room.mu.Unlock()
+		return
+	}
+	playerIndex := room.state.CurrentPlayer
+	move, ok := game.PickMove(room.state, room.state.Hands[playerIndex])
+	if !ok {
+		room.mu.Unlock()
+		return
+	}
+	state, err := game.ApplyMove(room.state, playerIndex, move.Card, move.FaceDown)
+	if err != nil {
+		log.Printf("auto-play move failed: %v", err)
+		room.mu.Unlock()
+		return
+	}
+	room.state = state
+	room.store.Save(room.id, room.state)
+	gameOver := game.IsGameOver(room.state)
+	if !gameOver {
+		room.startTurnTimerLocked()
+	}
 	room.mu.Unlock()
 
 	if gameOver {
@@ -304,7 +363,7 @@ func (room *room) stateMessageFor(playerIndex int) map[string]any {
 		"your_hand":        yourHand,
 		"opponents":        opponents,
 		"current_turn":     room.players[room.state.CurrentPlayer].displayName,
-		"turn_ends_at":     time.Now().Add(60 * time.Second).UTC().Format(time.RFC3339),
+		"turn_ends_at":     room.turnExpiresAt.Format(time.RFC3339),
 	}
 }
 

--- a/services/ws/server_test.go
+++ b/services/ws/server_test.go
@@ -97,6 +97,27 @@ func TestWebSocketPlayCardPersistsUpdatedRoomState(t *testing.T) {
 	}
 }
 
+func TestWebSocketTurnTimerExpiryAutoPlaysAndBroadcastsStateUpdate(t *testing.T) {
+	server := NewGameServerWithOptions("test-secret", newMemoryStateStore(), 20*time.Millisecond)
+	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))
+	defer httpServer.Close()
+
+	clients := connectPlayers(t, httpServer.URL, "test-secret", "room-autoplay", []string{"Alice", "Bob", "Carol", "Dave"})
+	defer closeClients(clients)
+
+	starter := readInitialUpdatesAndFindStarter(t, clients)
+
+	message := readTypedMessage(t, clients[starter], "state_update")
+	if hasCard(message, "spades", "7") {
+		t.Fatal("timer expiry did not auto-play the seven of spades")
+	}
+	board := message["board"].(map[string]any)
+	spades := board["spades"].(map[string]any)
+	if spades["low"].(float64) != 7 || spades["high"].(float64) != 7 {
+		t.Fatalf("unexpected spades board after auto-play: %+v", spades)
+	}
+}
+
 func TestWebSocketPlaceFaceDownRejectsWhenValidMoveExists(t *testing.T) {
 	server := NewGameServer("test-secret")
 	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))

--- a/web/src/pages/GamePage.test.tsx
+++ b/web/src/pages/GamePage.test.tsx
@@ -44,14 +44,16 @@ const liveState: GameSocketState = {
 }
 
 beforeEach(() => {
-  localStorage.setItem('seven_spade_auth_token', 'test-token')
-  vi.mocked(useGameSocket).mockReturnValue(liveState)
+	localStorage.setItem('seven_spade_auth_token', 'test-token')
+	vi.setSystemTime(new Date('2026-05-16T12:00:00Z'))
+	vi.mocked(useGameSocket).mockReturnValue(liveState)
 })
 
 afterEach(() => {
-  cleanup()
-  localStorage.clear()
-  vi.clearAllMocks()
+	cleanup()
+	vi.useRealTimers()
+	localStorage.clear()
+	vi.clearAllMocks()
 })
 
 function renderGame() {
@@ -109,5 +111,14 @@ test('shows face-down selection modal when your turn has no valid moves', () => 
 
   fireEvent.click(screen.getByRole('button', { name: /Place A of Hearts face down/i }))
 
-  expect(sendFaceDown).toHaveBeenCalledWith({ rank: 'A', suit: 'Hearts' })
+	expect(sendFaceDown).toHaveBeenCalledWith({ rank: 'A', suit: 'Hearts' })
+})
+
+test('shows a countdown timer bar for the active turn', () => {
+	renderGame()
+
+	const timer = screen.getByRole('timer', { name: /Turn timer/i })
+
+	expect(timer).toHaveTextContent('00:18')
+	expect(screen.getByLabelText(/Turn time remaining/i)).toHaveStyle({ width: '30%' })
 })

--- a/web/src/pages/GamePage.tsx
+++ b/web/src/pages/GamePage.tsx
@@ -44,6 +44,7 @@ export function GamePage() {
 
   const statusLabel = game.status === 'open' ? 'Connected' : game.status
   const turnLabel = game.currentTurnName ? `Turn: ${game.currentTurnName}` : 'Waiting for turn'
+	const turnClock = game.turnEndsAt ? getTurnClock(game.turnEndsAt) : null
 
   return (
     <SectionPanel
@@ -53,9 +54,9 @@ export function GamePage() {
         <div className="flex flex-wrap gap-2">
           <Badge tone={game.isMyTurn ? 'playing' : 'waiting'}>{game.isMyTurn ? 'Your turn' : turnLabel}</Badge>
           <Badge tone={connectionTone[game.status]}>{statusLabel}</Badge>
-          {game.turnEndsAt ? (
-            <span className="rounded-spade-pill border border-spade-gold-light/40 bg-spade-gold/15 px-3 py-1 font-mono text-xs text-spade-gold-light">
-              {formatTurnClock(game.turnEndsAt)}
+          {turnClock ? (
+            <span role="timer" aria-label="Turn timer" className="rounded-spade-pill border border-spade-gold-light/40 bg-spade-gold/15 px-3 py-1 font-mono text-xs text-spade-gold-light">
+              {turnClock.label}
             </span>
           ) : null}
         </div>
@@ -69,6 +70,16 @@ export function GamePage() {
         </div>
 
         <GameBoard rows={game.boardRows} />
+
+        {turnClock ? (
+          <div className="rounded-spade-pill border border-spade-cream/10 bg-spade-bg/70 p-1" aria-label="Turn countdown">
+            <div
+              aria-label="Turn time remaining"
+              className="h-2 rounded-spade-pill bg-gradient-to-r from-spade-gold-light to-spade-gold transition-[width] duration-500"
+              style={{ width: `${turnClock.percentRemaining}%` }}
+            />
+          </div>
+        ) : null}
 
         <CardStack
           cards={visibleHand}
@@ -128,12 +139,15 @@ export function GamePage() {
   )
 }
 
-function formatTurnClock(turnEndsAt: string): string {
+function getTurnClock(turnEndsAt: string): { label: string; percentRemaining: number } {
   const endsAt = Date.parse(turnEndsAt)
   if (Number.isNaN(endsAt)) {
-    return 'Live'
+    return { label: 'Live', percentRemaining: 100 }
   }
 
   const seconds = Math.max(0, Math.ceil((endsAt - Date.now()) / 1000))
-  return `00:${String(seconds).padStart(2, '0')}`
+  return {
+    label: `00:${String(seconds).padStart(2, '0')}`,
+    percentRemaining: Math.max(0, Math.min(100, Math.round((seconds / 60) * 100))),
+  }
 }


### PR DESCRIPTION
Closes #13

## Summary
- Added deterministic auto-play move selection for timer expiry.
- Started/reset per-turn WebSocket timers and broadcast normal state updates after auto-play.
- Added the compact game-table countdown bar on the React board.

## Changes
- services/ws/game/bot.go and bot tests cover PickMove valid, face-down, and deterministic behavior.
- services/ws/server.go and server tests cover timer expiry auto-playing the starter move.
- web/src/pages/GamePage.tsx and tests render the Seven Spade timer badge/bar from turn_ends_at.

## Decisions
- Kept the server default turn duration at 60s for the current in-memory WebSocket room model, with a constructor override for integration tests until room metadata is wired into ws.
- Used the existing turn_ends_at payload as the frontend countdown source to avoid a second protocol field.