### PR TITLE
Game over + scoring

### DIFF
--- a/services/ws/server.go
+++ b/services/ws/server.go
@@ -333,12 +333,32 @@ func (room *room) results() []map[string]any {
 		}
 		results = append(results, map[string]any{
 			"display_name":   player.displayName,
+			"facedown_cards": revealedFaceDownCards(room.state, player.index),
 			"penalty_points": scores[player.index],
 			"rank":           rank,
 			"is_winner":      scores[player.index] == lowest,
 		})
 	}
 	return results
+}
+
+func revealedFaceDownCards(state game.GameState, playerIndex int) []map[string]any {
+	cards := make([]map[string]any, 0, len(state.FaceDown[playerIndex]))
+	for _, card := range state.FaceDown[playerIndex] {
+		cards = append(cards, map[string]any{
+			"suit":   string(card.Suit),
+			"rank":   rankString(card.Rank),
+			"points": scoringValue(card, state.CloseMethod),
+		})
+	}
+	return cards
+}
+
+func scoringValue(card game.Card, method game.CloseMethod) int {
+	if card.Rank == game.Ace && method == game.CloseLow {
+		return 1
+	}
+	return card.PointValue()
 }
 
 func (player *player) send(message map[string]any) {

--- a/services/ws/server_test.go
+++ b/services/ws/server_test.go
@@ -152,6 +152,56 @@ func TestRoomResultsIncludeRevealedFaceDownCardsWithPointValues(t *testing.T) {
 	}
 }
 
+func TestWebSocketBroadcastsGameOverAfterFinalMove(t *testing.T) {
+	server := NewGameServer("test-secret")
+	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))
+	defer httpServer.Close()
+
+	clients := connectPlayers(t, httpServer.URL, "test-secret", "room-game-over", []string{"Alice", "Bob", "Carol", "Dave"})
+	defer closeClients(clients)
+	readInitialUpdatesAndFindStarter(t, clients)
+
+	room := server.rooms["room-game-over"]
+	room.mu.Lock()
+	room.state = game.NewGameState()
+	room.state.Board[game.Spades] = game.SuitSequence{Low: game.Seven, High: game.Seven}
+	room.state.Hands[0] = []game.Card{{Suit: game.Spades, Rank: game.Six}}
+	room.state.FaceDown[0] = []game.Card{{Suit: game.Clubs, Rank: game.Five}}
+	room.state.FaceDown[1] = []game.Card{{Suit: game.Hearts, Rank: game.Five}}
+	room.state.FaceDown[2] = []game.Card{{Suit: game.Diamonds, Rank: game.Jack}}
+	room.state.FaceDown[3] = []game.Card{{Suit: game.Spades, Rank: game.King}}
+	room.state.CurrentPlayer = 0
+	room.mu.Unlock()
+
+	if err := clients[0].WriteJSON(map[string]any{"type": "play_card", "suit": "spades", "rank": "6"}); err != nil {
+		t.Fatalf("write final move: %v", err)
+	}
+
+	for index, client := range clients {
+		message := readTypedMessage(t, client, "game_over")
+		results := message["results"].([]any)
+		if len(results) != 4 {
+			t.Fatalf("client %d expected four results, got %+v", index, message)
+		}
+		alice := results[0].(map[string]any)
+		if alice["display_name"] != "Alice" || alice["penalty_points"] != float64(5) || alice["rank"] != float64(1) || alice["is_winner"] != true {
+			t.Fatalf("client %d unexpected Alice result: %+v", index, alice)
+		}
+		bob := results[1].(map[string]any)
+		if bob["rank"] != float64(1) || bob["is_winner"] != true {
+			t.Fatalf("client %d expected Bob to share winner rank: %+v", index, bob)
+		}
+		cards := alice["facedown_cards"].([]any)
+		if len(cards) != 1 {
+			t.Fatalf("client %d expected Alice revealed card, got %+v", index, alice)
+		}
+		card := cards[0].(map[string]any)
+		if card["rank"] != "5" || card["suit"] != "clubs" || card["points"] != float64(5) {
+			t.Fatalf("client %d unexpected revealed card: %+v", index, card)
+		}
+	}
+}
+
 func TestWebSocketUnknownMessageTypeReturnsTypeError(t *testing.T) {
 	server := NewGameServer("test-secret")
 	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))

--- a/services/ws/server_test.go
+++ b/services/ws/server_test.go
@@ -116,6 +116,42 @@ func TestWebSocketPlaceFaceDownRejectsWhenValidMoveExists(t *testing.T) {
 	}
 }
 
+func TestRoomResultsIncludeRevealedFaceDownCardsWithPointValues(t *testing.T) {
+	room := &room{
+		players: []*player{
+			{displayName: "Alice", index: 0},
+			{displayName: "Bob", index: 1},
+			{displayName: "Carol", index: 2},
+			{displayName: "Dave", index: 3},
+		},
+		state: game.NewGameState(),
+	}
+	room.state.CloseMethod = game.CloseLow
+	room.state.FaceDown[0] = []game.Card{{Suit: game.Hearts, Rank: game.Ace}, {Suit: game.Clubs, Rank: game.Five}}
+	room.state.FaceDown[1] = []game.Card{{Suit: game.Spades, Rank: game.Six}}
+	room.state.FaceDown[2] = []game.Card{{Suit: game.Diamonds, Rank: game.Nine}}
+	room.state.FaceDown[3] = []game.Card{{Suit: game.Clubs, Rank: game.Ten}}
+
+	results := room.results()
+	alice := results[0]
+	if alice["penalty_points"] != 6 {
+		t.Fatalf("expected Alice score 6, got %+v", alice)
+	}
+	cards := alice["facedown_cards"].([]map[string]any)
+	if len(cards) != 2 {
+		t.Fatalf("expected two revealed cards, got %+v", cards)
+	}
+	if cards[0]["rank"] != "A" || cards[0]["suit"] != "hearts" || cards[0]["points"] != 1 {
+		t.Fatalf("unexpected revealed ace payload: %+v", cards[0])
+	}
+	if cards[1]["rank"] != "5" || cards[1]["suit"] != "clubs" || cards[1]["points"] != 5 {
+		t.Fatalf("unexpected revealed five payload: %+v", cards[1])
+	}
+	if alice["rank"] != 1 || alice["is_winner"] != true || results[1]["rank"] != 1 || results[1]["is_winner"] != true {
+		t.Fatalf("expected Alice and Bob to share rank 1: %+v", results)
+	}
+}
+
 func TestWebSocketUnknownMessageTypeReturnsTypeError(t *testing.T) {
 	server := NewGameServer("test-secret")
 	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))

--- a/services/ws/server_test.go
+++ b/services/ws/server_test.go
@@ -152,6 +152,28 @@ func TestRoomResultsIncludeRevealedFaceDownCardsWithPointValues(t *testing.T) {
 	}
 }
 
+func TestRoomResultsRanksPlayersByPenaltyTotalWithSkippedTieRanks(t *testing.T) {
+	room := &room{
+		players: []*player{
+			{displayName: "Alice", index: 0},
+			{displayName: "Bob", index: 1},
+			{displayName: "Carol", index: 2},
+			{displayName: "Dave", index: 3},
+		},
+		state: game.NewGameState(),
+	}
+	room.state.FaceDown[0] = []game.Card{{Suit: game.Clubs, Rank: game.Five}}
+	room.state.FaceDown[1] = []game.Card{{Suit: game.Hearts, Rank: game.Five}}
+	room.state.FaceDown[2] = []game.Card{{Suit: game.Diamonds, Rank: game.Nine}}
+	room.state.FaceDown[3] = []game.Card{{Suit: game.Spades, Rank: game.King}}
+
+	results := room.results()
+
+	if results[0]["rank"] != 1 || results[1]["rank"] != 1 || results[2]["rank"] != 3 || results[3]["rank"] != 4 {
+		t.Fatalf("expected competition ranks 1, 1, 3, 4, got %+v", results)
+	}
+}
+
 func TestWebSocketBroadcastsGameOverAfterFinalMove(t *testing.T) {
 	server := NewGameServer("test-secret")
 	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))

--- a/web/src/components/ScoreTable.tsx
+++ b/web/src/components/ScoreTable.tsx
@@ -1,7 +1,7 @@
 import { Badge } from './Badge'
 import type { Score } from '../types'
 
-export function ScoreTable({ scores }: { scores: Score[] }) {
+export function ScoreTable({ scores, winnerLabel = 'Winner' }: { scores: Score[]; winnerLabel?: string }) {
   return (
     <div className="overflow-hidden rounded-spade-lg border border-spade-cream/12 bg-[#2b302d]">
       <table aria-label="Score table" className="w-full text-sm">
@@ -21,7 +21,7 @@ export function ScoreTable({ scores }: { scores: Score[] }) {
               <td className="px-2 py-3">{score.player}</td>
               <td className="px-2 py-3 font-mono">{score.cardsLeft}</td>
               <td className="px-2 py-3 font-mono">{score.penalty}</td>
-              <td className="px-4 py-3">{score.winner ? <Badge tone="winner">Winner</Badge> : <span className="text-xs text-spade-gray-2">{score.result}</span>}</td>
+              <td className="px-4 py-3">{score.winner ? <Badge tone="winner">{winnerLabel}</Badge> : <span className="text-xs text-spade-gray-2">{score.result}</span>}</td>
             </tr>
           ))}
         </tbody>

--- a/web/src/hooks/useGameSocket.ts
+++ b/web/src/hooks/useGameSocket.ts
@@ -1,5 +1,5 @@
 import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { BoardRow, Card, Player, Toast } from '../types'
+import type { BoardRow, Card, GameResult, Player, Toast } from '../types'
 import { initialsForName, normalizeRank, ranks, suits, suitToWireSuit, wireSuitToSuit } from '../game/cards'
 
 const WS_URL = import.meta.env.VITE_WS_URL || 'ws://localhost:8081'
@@ -21,7 +21,13 @@ type StateUpdateMessage = {
 
 type GameOverMessage = {
   type: 'game_over'
-  results: Array<{ display_name: string; penalty_points: number; rank: number; is_winner: boolean }>
+  results: Array<{
+    display_name: string
+    penalty_points: number
+    rank: number
+    is_winner: boolean
+    facedown_cards?: Array<{ suit: string; rank: string | number; points: number }>
+  }>
 }
 
 type RematchStatusMessage = {
@@ -66,6 +72,7 @@ export type GameSocketState = {
   rematchVotes: number
   rematchTotal: number
   gameOver: boolean
+  results: GameResult[]
   sendPlayCard: (card: Card) => void
   sendFaceDown: (card: Card) => void
   sendRematchVote: () => void
@@ -84,6 +91,7 @@ export function useGameSocket(roomId: string | undefined, token: string | null):
   const [rematchVotes, setRematchVotes] = useState(0)
   const [rematchTotal, setRematchTotal] = useState(4)
   const [gameOver, setGameOver] = useState(false)
+  const [results, setResults] = useState<GameResult[]>([])
   const [connectionAttempt, setConnectionAttempt] = useState(0)
   const socketRef = useRef<WebSocket | null>(null)
 
@@ -113,6 +121,7 @@ export function useGameSocket(roomId: string | undefined, token: string | null):
         setRematchVotes,
         setRematchTotal,
         setGameOver,
+        setResults,
       })
     }
 
@@ -175,6 +184,7 @@ export function useGameSocket(roomId: string | undefined, token: string | null):
     rematchVotes,
     rematchTotal,
     gameOver,
+    results,
     sendPlayCard,
     sendFaceDown,
     sendRematchVote,
@@ -191,6 +201,7 @@ export function useGameSocket(roomId: string | undefined, token: string | null):
     rematchVotes,
     rematchTotal,
     gameOver,
+    results,
     sendPlayCard,
     sendFaceDown,
     sendRematchVote,
@@ -211,6 +222,7 @@ function handleMessage(
     setRematchVotes: (votes: number) => void
     setRematchTotal: (total: number) => void
     setGameOver: (gameOver: boolean) => void
+    setResults: (results: GameResult[]) => void
   },
 ) {
   let message: GameSocketMessage
@@ -233,18 +245,21 @@ function handleMessage(
     setters.setCurrentTurnName(isMyTurn ? 'You' : message.current_turn)
     setters.setTurnEndsAt(message.turn_ends_at ?? null)
     setters.setGameOver(false)
+    setters.setResults([])
     return
   }
 
   if (message.type === 'game_over') {
     setters.setGameOver(true)
-    setters.setPlayers(message.results.map((result, index) => ({
-      name: result.display_name,
-      initials: initialsForName(result.display_name),
+    const results = message.results.map(toGameResult)
+    setters.setResults(results)
+    setters.setPlayers(results.map((result, index) => ({
+      name: result.player,
+      initials: initialsForName(result.player),
       cardsLeft: 0,
-      faceDownCount: 0,
+      faceDownCount: result.faceDownCards.length,
       tone: playerTone(index),
-      winner: result.is_winner,
+      winner: result.winner,
     })))
     return
   }
@@ -314,6 +329,19 @@ function toCard(card: { suit: string; rank: string | number; valid?: boolean }):
     suit: wireSuitToSuit[card.suit] ?? 'Spades',
     rank: normalizeRank(card.rank),
     playable: Boolean(card.valid),
+  }
+}
+
+function toGameResult(result: GameOverMessage['results'][number]): GameResult {
+  return {
+    player: result.display_name,
+    rank: result.rank,
+    penalty: result.penalty_points,
+    winner: result.is_winner,
+    faceDownCards: (result.facedown_cards ?? []).map((card) => ({
+      ...toCard(card),
+      points: card.points,
+    })),
   }
 }
 

--- a/web/src/pages/GamePage.test.tsx
+++ b/web/src/pages/GamePage.test.tsx
@@ -37,6 +37,7 @@ const liveState: GameSocketState = {
   rematchVotes: 0,
   rematchTotal: 4,
   gameOver: false,
+  results: [],
   sendPlayCard,
   sendFaceDown,
   sendRematchVote: vi.fn(),
@@ -110,4 +111,52 @@ test('shows face-down selection modal when your turn has no valid moves', () => 
   fireEvent.click(screen.getByRole('button', { name: /Place A of Hearts face down/i }))
 
   expect(sendFaceDown).toHaveBeenCalledWith({ rank: 'A', suit: 'Hearts' })
+})
+
+test('renders game-over scores with revealed penalty cards and shared winners', () => {
+  const sendRematchVote = vi.fn()
+  vi.mocked(useGameSocket).mockReturnValue({
+    ...liveState,
+    gameOver: true,
+    rematchVotes: 0,
+    rematchTotal: 4,
+    results: [
+      {
+        player: 'You',
+        rank: 1,
+        penalty: 5,
+        winner: true,
+        faceDownCards: [{ rank: '5', suit: 'Clubs', points: 5 }],
+      },
+      {
+        player: 'Budi',
+        rank: 1,
+        penalty: 5,
+        winner: true,
+        faceDownCards: [{ rank: 'A', suit: 'Hearts', points: 1 }, { rank: '4', suit: 'Spades', points: 4 }],
+      },
+      {
+        player: 'Santi',
+        rank: 3,
+        penalty: 12,
+        winner: false,
+        faceDownCards: [{ rank: 'Q', suit: 'Diamonds', points: 12 }],
+      },
+    ],
+    players: [],
+    sendRematchVote,
+  })
+
+  renderGame()
+
+  expect(screen.getByRole('table', { name: 'Score table' })).toHaveTextContent('You')
+  expect(screen.getByRole('table', { name: 'Score table' })).toHaveTextContent('5')
+  expect(screen.getAllByText('Shared winner')).toHaveLength(2)
+  expect(screen.getByText('A of Hearts')).toBeInTheDocument()
+  expect(screen.getByText('+1')).toBeInTheDocument()
+  expect(screen.getByText('Q of Diamonds')).toBeInTheDocument()
+  expect(screen.getByText('+12')).toBeInTheDocument()
+
+  fireEvent.click(screen.getByRole('button', { name: /Vote rematch/i }))
+  expect(sendRematchVote).toHaveBeenCalledOnce()
 })

--- a/web/src/pages/GamePage.tsx
+++ b/web/src/pages/GamePage.tsx
@@ -136,12 +136,14 @@ export function GamePage() {
 function GameOverPanel({ roomId, game }: { roomId: string | undefined; game: ReturnType<typeof useGameSocket> }) {
   const navigate = useNavigate()
   const hasSharedWin = game.results.filter((result) => result.winner).length > 1
+  const winnerLabel = hasSharedWin ? 'Shared winner' : 'Winner'
+  const rematchProgress = (game.rematchVotes / game.rematchTotal) * 100
   const scores = game.results.map((result) => ({
     rank: result.rank,
     player: result.player,
     cardsLeft: 0,
     penalty: result.penalty,
-    result: result.winner ? (hasSharedWin ? 'Shared winner' : 'Winner') : 'Finished',
+    result: result.winner ? winnerLabel : 'Finished',
     winner: result.winner,
   }))
 
@@ -153,7 +155,7 @@ function GameOverPanel({ roomId, game }: { roomId: string | undefined; game: Ret
     >
       <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_340px]">
         <div className="grid gap-4">
-          <ScoreTable scores={scores} winnerLabel={hasSharedWin ? 'Shared winner' : 'Winner'} />
+          <ScoreTable scores={scores} winnerLabel={winnerLabel} />
           <RevealedPenaltyCards results={game.results} />
         </div>
 
@@ -168,7 +170,7 @@ function GameOverPanel({ roomId, game }: { roomId: string | undefined; game: Ret
             <Button variant="ghost" onClick={() => navigate('/history')}>View history</Button>
           </div>
           <div className="mt-4 h-2 overflow-hidden rounded-full bg-spade-bg/70">
-            <div className="h-full rounded-full bg-spade-gold-light" style={{ width: `${(game.rematchVotes / game.rematchTotal) * 100}%` }} />
+            <div className="h-full rounded-full bg-spade-gold-light" style={{ width: `${rematchProgress}%` }} />
           </div>
           <p className="mt-2 font-mono text-xs text-spade-gold-light">{game.rematchVotes} / {game.rematchTotal} voted</p>
         </div>
@@ -183,28 +185,36 @@ function RevealedPenaltyCards({ results }: { results: GameResult[] }) {
       <h3 className="text-lg font-medium">Revealed penalty cards</h3>
       <p className="mt-1 text-sm text-spade-gray-2">Face-down values are shown after the round ends.</p>
       <div className="mt-4 grid gap-3 md:grid-cols-2">
-        {results.map((result) => (
-          <div key={result.player} className={`rounded-spade-md border p-3 ${result.winner ? 'border-spade-gold/40 bg-spade-gold/10' : 'border-spade-cream/10 bg-spade-bg/45'}`}>
-            <div className="mb-3 flex items-center justify-between gap-3">
-              <div>
-                <h4 className="font-medium">{result.player}</h4>
-                <p className="font-mono text-xs text-spade-gray-2">Rank {result.rank} · {result.penalty} penalty</p>
-              </div>
-              {result.winner ? <Badge tone="winner">Winner</Badge> : null}
-            </div>
-            <div className="flex flex-wrap gap-2">
-              {result.faceDownCards.length === 0 ? (
-                <span className="text-sm text-spade-gray-2">No penalty cards</span>
-              ) : result.faceDownCards.map((card) => (
-                <div key={`${result.player}-${card.rank}-${card.suit}`} className="flex items-center gap-2 rounded-spade-sm border border-spade-cream/10 bg-spade-bg/70 px-2 py-1">
-                  <CardFace card={card} size="sm" interactive={false} ariaLabel={`${card.rank} of ${card.suit}`} />
-                  <span className="grid gap-1">
-                    <span className="text-xs text-spade-cream">{card.rank} of {card.suit}</span>
-                    <span className="font-mono text-xs text-spade-gold-light">+{card.points}</span>
-                  </span>
-                </div>
-              ))}
-            </div>
+        {results.map((result) => <RevealedPenaltyCardGroup key={result.player} result={result} />)}
+      </div>
+    </div>
+  )
+}
+
+function RevealedPenaltyCardGroup({ result }: { result: GameResult }) {
+  const panelClassName = result.winner
+    ? 'border-spade-gold/40 bg-spade-gold/10'
+    : 'border-spade-cream/10 bg-spade-bg/45'
+
+  return (
+    <div className={`rounded-spade-md border p-3 ${panelClassName}`}>
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div>
+          <h4 className="font-medium">{result.player}</h4>
+          <p className="font-mono text-xs text-spade-gray-2">Rank {result.rank} · {result.penalty} penalty</p>
+        </div>
+        {result.winner ? <Badge tone="winner">Winner</Badge> : null}
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {result.faceDownCards.length === 0 ? <span className="text-sm text-spade-gray-2">No penalty cards</span> : null}
+        {result.faceDownCards.map((card) => (
+          <div key={`${result.player}-${card.rank}-${card.suit}`} className="flex items-center gap-2 rounded-spade-sm border border-spade-cream/10 bg-spade-bg/70 px-2 py-1">
+            <CardFace card={card} size="sm" interactive={false} ariaLabel={`${card.rank} of ${card.suit}`} />
+            <span className="grid gap-1">
+              <span className="text-xs text-spade-cream">{card.rank} of {card.suit}</span>
+              <span className="font-mono text-xs text-spade-gold-light">+{card.points}</span>
+            </span>
           </div>
         ))}
       </div>

--- a/web/src/pages/GamePage.tsx
+++ b/web/src/pages/GamePage.tsx
@@ -7,11 +7,12 @@ import { CardStack } from '../components/CardStack'
 import { GameBoard } from '../components/GameBoard'
 import { Modal } from '../components/Modal'
 import { PlayerAvatar } from '../components/PlayerAvatar'
+import { ScoreTable } from '../components/ScoreTable'
 import { SectionPanel } from '../components/SectionPanel'
 import { ToastStack } from '../components/ToastStack'
 import { useAuth } from '../hooks/useAuth'
 import { useGameSocket } from '../hooks/useGameSocket'
-import type { Card } from '../types'
+import type { Card, GameResult } from '../types'
 
 const connectionTone = {
   idle: 'waiting',
@@ -44,6 +45,10 @@ export function GamePage() {
 
   const statusLabel = game.status === 'open' ? 'Connected' : game.status
   const turnLabel = game.currentTurnName ? `Turn: ${game.currentTurnName}` : 'Waiting for turn'
+
+  if (game.gameOver) {
+    return <GameOverPanel roomId={roomId} game={game} />
+  }
 
   return (
     <SectionPanel
@@ -125,6 +130,85 @@ export function GamePage() {
         ) : null}
       </div>
     </SectionPanel>
+  )
+}
+
+function GameOverPanel({ roomId, game }: { roomId: string | undefined; game: ReturnType<typeof useGameSocket> }) {
+  const navigate = useNavigate()
+  const hasSharedWin = game.results.filter((result) => result.winner).length > 1
+  const scores = game.results.map((result) => ({
+    rank: result.rank,
+    player: result.player,
+    cardsLeft: 0,
+    penalty: result.penalty,
+    result: result.winner ? (hasSharedWin ? 'Shared winner' : 'Winner') : 'Finished',
+    winner: result.winner,
+  }))
+
+  return (
+    <SectionPanel
+      title="Results and rematch"
+      eyebrow={roomId ? `Room ${roomId}` : 'Game over + scoring'}
+      action={<Badge tone="winner">Round over</Badge>}
+    >
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_340px]">
+        <div className="grid gap-4">
+          <ScoreTable scores={scores} winnerLabel={hasSharedWin ? 'Shared winner' : 'Winner'} />
+          <RevealedPenaltyCards results={game.results} />
+        </div>
+
+        <div className="rounded-spade-lg border border-spade-gold/30 bg-spade-gold/10 p-4">
+          <h3 className="text-lg font-medium">Rematch vote</h3>
+          <p className="mt-1 text-sm text-spade-gray-2">
+            The game restarts in the same room once every player votes for a rematch.
+          </p>
+          <div className="mt-4 grid gap-2">
+            <Button onClick={game.sendRematchVote}>Vote rematch</Button>
+            <Button variant="secondary" onClick={() => navigate('/lobby')}>Leave room</Button>
+            <Button variant="ghost" onClick={() => navigate('/history')}>View history</Button>
+          </div>
+          <div className="mt-4 h-2 overflow-hidden rounded-full bg-spade-bg/70">
+            <div className="h-full rounded-full bg-spade-gold-light" style={{ width: `${(game.rematchVotes / game.rematchTotal) * 100}%` }} />
+          </div>
+          <p className="mt-2 font-mono text-xs text-spade-gold-light">{game.rematchVotes} / {game.rematchTotal} voted</p>
+        </div>
+      </div>
+    </SectionPanel>
+  )
+}
+
+function RevealedPenaltyCards({ results }: { results: GameResult[] }) {
+  return (
+    <div className="rounded-spade-lg border border-spade-cream/10 bg-[#2b302d] p-4">
+      <h3 className="text-lg font-medium">Revealed penalty cards</h3>
+      <p className="mt-1 text-sm text-spade-gray-2">Face-down values are shown after the round ends.</p>
+      <div className="mt-4 grid gap-3 md:grid-cols-2">
+        {results.map((result) => (
+          <div key={result.player} className={`rounded-spade-md border p-3 ${result.winner ? 'border-spade-gold/40 bg-spade-gold/10' : 'border-spade-cream/10 bg-spade-bg/45'}`}>
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <div>
+                <h4 className="font-medium">{result.player}</h4>
+                <p className="font-mono text-xs text-spade-gray-2">Rank {result.rank} · {result.penalty} penalty</p>
+              </div>
+              {result.winner ? <Badge tone="winner">Winner</Badge> : null}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {result.faceDownCards.length === 0 ? (
+                <span className="text-sm text-spade-gray-2">No penalty cards</span>
+              ) : result.faceDownCards.map((card) => (
+                <div key={`${result.player}-${card.rank}-${card.suit}`} className="flex items-center gap-2 rounded-spade-sm border border-spade-cream/10 bg-spade-bg/70 px-2 py-1">
+                  <CardFace card={card} size="sm" interactive={false} ariaLabel={`${card.rank} of ${card.suit}`} />
+                  <span className="grid gap-1">
+                    <span className="text-xs text-spade-cream">{card.rank} of {card.suit}</span>
+                    <span className="font-mono text-xs text-spade-gold-light">+{card.points}</span>
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
   )
 }
 

--- a/web/src/pages/GamePage.tsx
+++ b/web/src/pages/GamePage.tsx
@@ -11,7 +11,7 @@ import { ScoreTable } from '../components/ScoreTable'
 import { SectionPanel } from '../components/SectionPanel'
 import { ToastStack } from '../components/ToastStack'
 import { useAuth } from '../hooks/useAuth'
-import { useGameSocket } from '../hooks/useGameSocket'
+import { useGameSocket, type GameSocketState } from '../hooks/useGameSocket'
 import type { Card, GameResult } from '../types'
 
 const connectionTone = {
@@ -45,6 +45,7 @@ export function GamePage() {
 
   const statusLabel = game.status === 'open' ? 'Connected' : game.status
   const turnLabel = game.currentTurnName ? `Turn: ${game.currentTurnName}` : 'Waiting for turn'
+  const tableStateMessage = getTableStateMessage(game.isMyTurn, hasValidMoves)
 
   if (game.gameOver) {
     return <GameOverPanel roomId={roomId} game={game} />
@@ -89,9 +90,7 @@ export function GamePage() {
               <Badge tone={game.isMyTurn ? 'playing' : 'waiting'}>{turnLabel}</Badge>
             </div>
             <p className="text-sm text-spade-gray-2">
-              {game.isMyTurn
-                ? hasValidMoves ? 'Play a highlighted card to extend an open suit.' : 'No valid moves. Choose a penalty card to place face down.'
-                : 'Waiting for the active player to move.'}
+              {tableStateMessage}
             </p>
           </div>
 
@@ -133,7 +132,7 @@ export function GamePage() {
   )
 }
 
-function GameOverPanel({ roomId, game }: { roomId: string | undefined; game: ReturnType<typeof useGameSocket> }) {
+function GameOverPanel({ roomId, game }: { roomId: string | undefined; game: GameSocketState }) {
   const navigate = useNavigate()
   const hasSharedWin = game.results.filter((result) => result.winner).length > 1
   const winnerLabel = hasSharedWin ? 'Shared winner' : 'Winner'
@@ -220,6 +219,18 @@ function RevealedPenaltyCardGroup({ result }: { result: GameResult }) {
       </div>
     </div>
   )
+}
+
+function getTableStateMessage(isMyTurn: boolean, hasValidMoves: boolean): string {
+  if (!isMyTurn) {
+    return 'Waiting for the active player to move.'
+  }
+
+  if (!hasValidMoves) {
+    return 'No valid moves. Choose a penalty card to place face down.'
+  }
+
+  return 'Play a highlighted card to extend an open suit.'
 }
 
 function formatTurnClock(turnEndsAt: string): string {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -39,6 +39,18 @@ export type Score = {
   me?: boolean
 }
 
+export type RevealedPenaltyCard = Card & {
+  points: number
+}
+
+export type GameResult = {
+  rank: number
+  player: string
+  penalty: number
+  winner: boolean
+  faceDownCards: RevealedPenaltyCard[]
+}
+
 export type ToastTone = 'success' | 'warn' | 'info' | 'error'
 
 export type Toast = {


### PR DESCRIPTION
Closes #15

## Summary
Implemented the game-over scoring path so the WebSocket payload includes final ranks, winner flags, and revealed face-down penalty card values, and the live game page renders the results/rematch view when the round ends.

## Changes
- Extended `game_over` results with revealed face-down cards and scoring values.
- Added backend coverage for revealed card payloads, ace low scoring, and tied winner ranking.
- Stored game-over results in `useGameSocket` and rendered the Seven Spade results UI from live data.
- Added component coverage for scores, revealed penalty cards, shared winners, and rematch voting.

## Decisions
- Kept the results view inside `GamePage` so the live WebSocket state remains available without introducing a new persistence or navigation handoff.
- Preserved existing score-table styling and added a configurable shared-winner label for tied wins.