### PR TITLE
Disconnect + reconnect

### DIFF
--- a/services/ws/server.go
+++ b/services/ws/server.go
@@ -47,10 +47,12 @@ type memoryStateStore struct {
 }
 
 type player struct {
-	displayName string
-	index       int
-	conn        *websocket.Conn
-	mu          sync.Mutex
+	sub          string
+	displayName  string
+	index        int
+	conn         *websocket.Conn
+	disconnected bool
+	mu           sync.Mutex
 }
 
 var orderedSuits = []game.Suit{game.Spades, game.Hearts, game.Diamonds, game.Clubs}
@@ -70,11 +72,13 @@ type clientMessage struct {
 }
 
 const (
-	messageTypeError         = "error"
-	messageTypeGameOver      = "game_over"
-	messageTypePlaceFaceDown = "place_facedown"
-	messageTypePlayCard      = "play_card"
-	messageTypeStateUpdate   = "state_update"
+	messageTypeError              = "error"
+	messageTypeGameOver           = "game_over"
+	messageTypePlaceFaceDown      = "place_facedown"
+	messageTypePlayerDisconnected = "player_disconnected"
+	messageTypePlayerReconnected  = "player_reconnected"
+	messageTypePlayCard           = "play_card"
+	messageTypeStateUpdate        = "state_update"
 )
 
 func NewGameServer(jwtSecret string) *GameServer {
@@ -156,7 +160,7 @@ func (server *GameServer) handleWebSocket(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	room, player, err := server.joinRoom(roomID, claims, conn)
+	room, player, startedNow, err := server.joinRoom(roomID, claims, conn)
 	if err != nil {
 		if writeErr := conn.WriteJSON(errorMessage(err.Error())); writeErr != nil {
 			log.Printf("write websocket join error: %v", writeErr)
@@ -167,13 +171,15 @@ func (server *GameServer) handleWebSocket(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if room.started {
+	if startedNow {
 		room.broadcastState()
+	} else if room.started {
+		player.send(room.stateMessageFor(player.index))
 	}
 	go room.readLoop(player)
 }
 
-func (server *GameServer) joinRoom(roomID string, claims *tokenClaims, conn *websocket.Conn) (*room, *player, error) {
+func (server *GameServer) joinRoom(roomID string, claims *tokenClaims, conn *websocket.Conn) (*room, *player, bool, error) {
 	server.mu.Lock()
 	gameRoom := server.rooms[roomID]
 	if gameRoom == nil {
@@ -185,37 +191,64 @@ func (server *GameServer) joinRoom(roomID string, claims *tokenClaims, conn *web
 	gameRoom.mu.Lock()
 	defer gameRoom.mu.Unlock()
 	if gameRoom.started {
-		return nil, nil, fmt.Errorf("game already started")
+		for _, player := range gameRoom.players {
+			if player.sub == claims.Sub {
+				player.conn = conn
+				wasDisconnected := player.disconnected
+				player.disconnected = false
+				if wasDisconnected {
+					go gameRoom.broadcastPlayerConnection(messageTypePlayerReconnected, player.displayName, player.index)
+				}
+				return gameRoom, player, false, nil
+			}
+		}
+		return nil, nil, false, fmt.Errorf("game already started")
 	}
 	if len(gameRoom.players) >= game.PlayerCount {
-		return nil, nil, fmt.Errorf("room is full")
+		return nil, nil, false, fmt.Errorf("room is full")
 	}
-	player := &player{displayName: claims.DisplayName, index: len(gameRoom.players), conn: conn}
+	player := &player{sub: claims.Sub, displayName: claims.DisplayName, index: len(gameRoom.players), conn: conn}
 	gameRoom.players = append(gameRoom.players, player)
+	startedNow := false
 	if len(gameRoom.players) == game.PlayerCount {
 		state, starter := game.Deal(time.Now().UnixNano())
 		gameRoom.state = state
 		gameRoom.state.CurrentPlayer = starter
 		gameRoom.started = true
+		startedNow = true
 		gameRoom.store.Save(roomID, gameRoom.state)
 		gameRoom.startTurnTimerLocked()
 	}
-	return gameRoom, player, nil
+	return gameRoom, player, startedNow, nil
 }
 
 func (room *room) readLoop(player *player) {
+	conn := player.conn
 	defer func() {
-		if err := player.conn.Close(); err != nil {
+		room.handleDisconnect(player, conn)
+		if err := conn.Close(); err != nil {
 			log.Printf("close websocket read loop: %v", err)
 		}
 	}()
 	for {
 		var message clientMessage
-		if err := player.conn.ReadJSON(&message); err != nil {
+		if err := conn.ReadJSON(&message); err != nil {
 			return
 		}
 		room.handleMessage(player, message)
 	}
+}
+
+func (room *room) handleDisconnect(player *player, conn *websocket.Conn) {
+	room.mu.Lock()
+	if !room.started || player.disconnected || player.conn != conn {
+		room.mu.Unlock()
+		return
+	}
+	player.disconnected = true
+	room.mu.Unlock()
+
+	room.broadcastPlayerConnection(messageTypePlayerDisconnected, player.displayName, player.index)
 }
 
 func (room *room) handleMessage(player *player, message clientMessage) {
@@ -223,6 +256,11 @@ func (room *room) handleMessage(player *player, message clientMessage) {
 	if !room.started {
 		room.mu.Unlock()
 		player.sendError("game has not started")
+		return
+	}
+	if player.disconnected {
+		room.mu.Unlock()
+		player.sendError("player is disconnected")
 		return
 	}
 	if room.state.CurrentPlayer != player.index {
@@ -321,13 +359,16 @@ func applyClientMessage(state game.GameState, playerIndex int, message clientMes
 
 func (room *room) broadcastState() {
 	room.mu.Lock()
-	snapshots := make([]struct {
+	type stateSnapshot struct {
 		player  *player
 		message map[string]any
-	}, len(room.players))
-	for index, player := range room.players {
-		snapshots[index].player = player
-		snapshots[index].message = room.stateMessageFor(player.index)
+	}
+	snapshots := make([]stateSnapshot, 0, len(room.players))
+	for _, player := range room.players {
+		if player.disconnected {
+			continue
+		}
+		snapshots = append(snapshots, stateSnapshot{player: player, message: room.stateMessageFor(player.index)})
 	}
 	room.mu.Unlock()
 	for _, snapshot := range snapshots {
@@ -351,6 +392,7 @@ func (room *room) stateMessageFor(playerIndex int) map[string]any {
 			"display_name":   player.displayName,
 			"hand_count":     len(room.state.Hands[player.index]),
 			"facedown_count": len(room.state.FaceDown[player.index]),
+			"disconnected":   player.disconnected,
 		})
 	}
 
@@ -364,6 +406,22 @@ func (room *room) stateMessageFor(playerIndex int) map[string]any {
 		"opponents":        opponents,
 		"current_turn":     room.players[room.state.CurrentPlayer].displayName,
 		"turn_ends_at":     room.turnExpiresAt.Format(time.RFC3339),
+	}
+}
+
+func (room *room) broadcastPlayerConnection(messageType string, displayName string, playerIndex int) {
+	room.mu.Lock()
+	message := map[string]any{"type": messageType, "display_name": displayName}
+	players := make([]*player, 0, len(room.players))
+	for _, player := range room.players {
+		if player.index != playerIndex && !player.disconnected {
+			players = append(players, player)
+		}
+	}
+	room.mu.Unlock()
+
+	for _, player := range players {
+		player.send(message)
 	}
 }
 

--- a/services/ws/server_test.go
+++ b/services/ws/server_test.go
@@ -118,6 +118,64 @@ func TestWebSocketTurnTimerExpiryAutoPlaysAndBroadcastsStateUpdate(t *testing.T)
 	}
 }
 
+func TestWebSocketDisconnectActivatesBotAndBroadcastsDisconnect(t *testing.T) {
+	server := NewGameServerWithOptions("test-secret", newMemoryStateStore(), 20*time.Millisecond)
+	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))
+	defer httpServer.Close()
+
+	clients := connectPlayers(t, httpServer.URL, "test-secret", "room-disconnect", []string{"Alice", "Bob", "Carol", "Dave"})
+	defer closeClients(clients)
+
+	starter := readInitialUpdatesAndFindStarter(t, clients)
+	if err := clients[starter].Close(); err != nil {
+		t.Fatalf("close starter connection: %v", err)
+	}
+
+	observer := clients[(starter+1)%len(clients)]
+	disconnect := readTypedMessage(t, observer, "player_disconnected")
+	if disconnect["display_name"] == "" {
+		t.Fatalf("disconnect event missing display name: %+v", disconnect)
+	}
+
+	update := readTypedMessage(t, observer, "state_update")
+	if update["current_turn"] == disconnect["display_name"] {
+		t.Fatalf("disconnected starter did not auto-play on their timer: %+v", update)
+	}
+	opponents := update["opponents"].([]any)
+	if !opponentDisconnected(opponents, disconnect["display_name"].(string)) {
+		t.Fatalf("state update did not mark disconnected opponent: %+v", opponents)
+	}
+}
+
+func TestWebSocketReconnectDeactivatesBotAndRestoresPlayerControl(t *testing.T) {
+	server := NewGameServerWithOptions("test-secret", newMemoryStateStore(), time.Hour)
+	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))
+	defer httpServer.Close()
+
+	names := []string{"Alice", "Bob", "Carol", "Dave"}
+	clients := connectPlayers(t, httpServer.URL, "test-secret", "room-reconnect", names)
+	defer closeClients(clients)
+
+	starter := readInitialUpdatesAndFindStarter(t, clients)
+	if err := clients[starter].Close(); err != nil {
+		t.Fatalf("close starter connection: %v", err)
+	}
+	observer := clients[(starter+1)%len(clients)]
+	readTypedMessage(t, observer, "player_disconnected")
+
+	reconnected := connectPlayer(t, httpServer.URL, "test-secret", "room-reconnect", names[starter])
+	defer reconnected.Close()
+
+	reconnect := readTypedMessage(t, observer, "player_reconnected")
+	if reconnect["display_name"] == "" {
+		t.Fatalf("reconnect event missing display name: %+v", reconnect)
+	}
+	update := readTypedMessage(t, reconnected, "state_update")
+	if !hasCard(update, "spades", "7") {
+		t.Fatalf("reconnected active player did not regain manual control: %+v", update)
+	}
+}
+
 func TestWebSocketPlaceFaceDownRejectsWhenValidMoveExists(t *testing.T) {
 	server := NewGameServer("test-secret")
 	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))
@@ -176,15 +234,19 @@ func connectPlayers(t *testing.T, baseURL, secret, roomID string, names []string
 	t.Helper()
 	clients := make([]*websocket.Conn, 0, len(names))
 	for _, name := range names {
-		token := signTestToken(t, secret, name)
-		conn, _, err := websocket.DefaultDialer.Dial("ws"+baseURL[len("http"):]+"/ws?room_id="+roomID+"&token="+token, nil)
-		if err != nil {
-			closeClients(clients)
-			t.Fatalf("dial %s: %v", name, err)
-		}
-		clients = append(clients, conn)
+		clients = append(clients, connectPlayer(t, baseURL, secret, roomID, name))
 	}
 	return clients
+}
+
+func connectPlayer(t *testing.T, baseURL, secret, roomID string, name string) *websocket.Conn {
+	t.Helper()
+	token := signTestToken(t, secret, name)
+	conn, _, err := websocket.DefaultDialer.Dial("ws"+baseURL[len("http"):]+"/ws?room_id="+roomID+"&token="+token, nil)
+	if err != nil {
+		t.Fatalf("dial %s: %v", name, err)
+	}
+	return conn
 }
 
 func signTestToken(t *testing.T, secret, displayName string) string {
@@ -248,6 +310,16 @@ func closeClients(clients []*websocket.Conn) {
 	for _, client := range clients {
 		_ = client.Close()
 	}
+}
+
+func opponentDisconnected(opponents []any, displayName string) bool {
+	for _, rawOpponent := range opponents {
+		opponent := rawOpponent.(map[string]any)
+		if opponent["display_name"] == displayName {
+			return opponent["disconnected"] == true
+		}
+	}
+	return false
 }
 
 func testDependencyChecks() map[string]dependencyCheck {

--- a/web/src/pages/GamePage.test.tsx
+++ b/web/src/pages/GamePage.test.tsx
@@ -122,3 +122,17 @@ test('shows a countdown timer bar for the active turn', () => {
 	expect(timer).toHaveTextContent('00:18')
 	expect(screen.getByLabelText(/Turn time remaining/i)).toHaveStyle({ width: '30%' })
 })
+
+test('shows a bot badge for disconnected players', () => {
+	vi.mocked(useGameSocket).mockReturnValue({
+		...liveState,
+		players: liveState.players.map((player) => (
+			player.name === 'Budi' ? { ...player, disconnected: true } : player
+		)),
+	})
+
+	renderGame()
+
+	expect(screen.getByText('Budi').closest('article')).toHaveClass('opacity-55')
+	expect(screen.getByText('Bot')).toBeInTheDocument()
+})


### PR DESCRIPTION
Closes #14

## Summary
- Handles WebSocket player disconnects by marking the player disconnected and letting the existing turn timer auto-play their moves.
- Allows the same JWT subject to reconnect to an active room, clears bot control, and resumes manual control.
- Covers reconnect/disconnect server behavior and the disconnected player visual indicator.

## Changes
- services/ws/server.go: tracks player identity and disconnected state, emits player_disconnected/player_reconnected events, and includes disconnected flags in state snapshots.
- services/ws/server_test.go: adds integration coverage for disconnect bot handoff and reconnect recovery.
- web/src/pages/GamePage.test.tsx: asserts disconnected opponents render with the bot indicator.

## Decisions
- Reused the existing turn timer auto-play path for disconnected players so bot-controlled turns match expired-timer behavior.
- Reconnect is keyed by JWT subject, not display name, to avoid display-name collisions.