### PR TITLE
Rematch

### DIFF
--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -136,7 +136,13 @@ Broadcast when any player votes for a rematch, showing current vote tally.
 {
   "type": "rematch_status",
   "votes": 2,
-  "total": 4
+  "total": 4,
+  "players": [
+    { "display_name": "Alice", "voted": true },
+    { "display_name": "Bob", "voted": true },
+    { "display_name": "Carol", "voted": false },
+    { "display_name": "Dave", "voted": false }
+  ]
 }
 ```
 

--- a/services/ws/server.go
+++ b/services/ws/server.go
@@ -34,6 +34,7 @@ type room struct {
 	turnExpiresAt     time.Time
 	turnTimer         *time.Timer
 	turnTimerToken    int
+	rematchVotes      map[int]bool
 	mu                sync.Mutex
 }
 
@@ -77,6 +78,9 @@ const (
 	messageTypePlaceFaceDown      = "place_facedown"
 	messageTypePlayerDisconnected = "player_disconnected"
 	messageTypePlayerReconnected  = "player_reconnected"
+	messageTypeRematchCancelled   = "rematch_cancelled"
+	messageTypeRematchStatus      = "rematch_status"
+	messageTypeRematchVote        = "rematch_vote"
 	messageTypePlayCard           = "play_card"
 	messageTypeStateUpdate        = "state_update"
 )
@@ -183,7 +187,7 @@ func (server *GameServer) joinRoom(roomID string, claims *tokenClaims, conn *web
 	server.mu.Lock()
 	gameRoom := server.rooms[roomID]
 	if gameRoom == nil {
-		gameRoom = &room{id: roomID, store: server.store, turnTimerDuration: server.turnTimerDuration}
+		gameRoom = &room{id: roomID, store: server.store, turnTimerDuration: server.turnTimerDuration, rematchVotes: map[int]bool{}}
 		server.rooms[roomID] = gameRoom
 	}
 	server.mu.Unlock()
@@ -246,8 +250,15 @@ func (room *room) handleDisconnect(player *player, conn *websocket.Conn) {
 		return
 	}
 	player.disconnected = true
+	cancelRematch := game.IsGameOver(room.state) && len(room.rematchVotes) > 0
+	if cancelRematch {
+		room.rematchVotes = map[int]bool{}
+	}
 	room.mu.Unlock()
 
+	if cancelRematch {
+		room.broadcastRematchCancelled()
+	}
 	room.broadcastPlayerConnection(messageTypePlayerDisconnected, player.displayName, player.index)
 }
 
@@ -261,6 +272,10 @@ func (room *room) handleMessage(player *player, message clientMessage) {
 	if player.disconnected {
 		room.mu.Unlock()
 		player.sendError("player is disconnected")
+		return
+	}
+	if message.Type == messageTypeRematchVote {
+		room.handleRematchVoteLocked(player)
 		return
 	}
 	if room.state.CurrentPlayer != player.index {
@@ -287,6 +302,32 @@ func (room *room) handleMessage(player *player, message clientMessage) {
 		room.broadcastGameOver()
 		return
 	}
+	room.broadcastState()
+}
+
+func (room *room) handleRematchVoteLocked(player *player) {
+	if !game.IsGameOver(room.state) {
+		room.mu.Unlock()
+		player.sendError("rematch is only available after game over")
+		return
+	}
+	if room.rematchVotes == nil {
+		room.rematchVotes = map[int]bool{}
+	}
+	room.rematchVotes[player.index] = true
+	if len(room.rematchVotes) < game.PlayerCount {
+		room.mu.Unlock()
+		room.broadcastRematchStatus()
+		return
+	}
+
+	state, starter := game.Deal(time.Now().UnixNano())
+	room.state = state
+	room.state.CurrentPlayer = starter
+	room.rematchVotes = map[int]bool{}
+	room.store.Save(room.id, room.state)
+	room.startTurnTimerLocked()
+	room.mu.Unlock()
 	room.broadcastState()
 }
 
@@ -427,12 +468,58 @@ func (room *room) broadcastPlayerConnection(messageType string, displayName stri
 
 func (room *room) broadcastGameOver() {
 	room.mu.Lock()
+	room.rematchVotes = map[int]bool{}
 	message := map[string]any{"type": messageTypeGameOver, "results": room.results()}
 	players := append([]*player(nil), room.players...)
 	room.mu.Unlock()
 	for _, player := range players {
 		player.send(message)
 	}
+}
+
+func (room *room) broadcastRematchStatus() {
+	room.mu.Lock()
+	message := room.rematchStatusMessageLocked()
+	players := connectedPlayersLocked(room.players)
+	room.mu.Unlock()
+	for _, player := range players {
+		player.send(message)
+	}
+}
+
+func (room *room) broadcastRematchCancelled() {
+	room.mu.Lock()
+	players := connectedPlayersLocked(room.players)
+	room.mu.Unlock()
+	for _, player := range players {
+		player.send(map[string]any{"type": messageTypeRematchCancelled})
+	}
+}
+
+func (room *room) rematchStatusMessageLocked() map[string]any {
+	players := make([]map[string]any, 0, len(room.players))
+	for _, player := range room.players {
+		players = append(players, map[string]any{
+			"display_name": player.displayName,
+			"voted":        room.rematchVotes[player.index],
+		})
+	}
+	return map[string]any{
+		"type":    messageTypeRematchStatus,
+		"votes":   len(room.rematchVotes),
+		"total":   game.PlayerCount,
+		"players": players,
+	}
+}
+
+func connectedPlayersLocked(players []*player) []*player {
+	connected := make([]*player, 0, len(players))
+	for _, player := range players {
+		if !player.disconnected {
+			connected = append(connected, player)
+		}
+	}
+	return connected
 }
 
 func (room *room) results() []map[string]any {

--- a/services/ws/server_test.go
+++ b/services/ws/server_test.go
@@ -303,6 +303,81 @@ func TestWebSocketBroadcastsGameOverAfterFinalMove(t *testing.T) {
 	}
 }
 
+func TestWebSocketRematchVotesStartNewGameInSameRoom(t *testing.T) {
+	server := NewGameServer("test-secret")
+	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))
+	defer httpServer.Close()
+
+	clients := connectPlayers(t, httpServer.URL, "test-secret", "room-rematch", []string{"Alice", "Bob", "Carol", "Dave"})
+	defer closeClients(clients)
+	readInitialUpdatesAndFindStarter(t, clients)
+	forceGameOverRoom(t, server.rooms["room-rematch"])
+	server.rooms["room-rematch"].broadcastGameOver()
+	for _, client := range clients {
+		readTypedMessage(t, client, "game_over")
+	}
+
+	for voter, client := range clients {
+		if err := client.WriteJSON(map[string]any{"type": "rematch_vote"}); err != nil {
+			t.Fatalf("write rematch vote %d: %v", voter, err)
+		}
+		if voter < len(clients)-1 {
+			for observer, observerClient := range clients {
+				message := readTypedMessage(t, observerClient, "rematch_status")
+				if message["votes"] != float64(voter+1) || message["total"] != float64(game.PlayerCount) {
+					t.Fatalf("observer %d unexpected rematch status after vote %d: %+v", observer, voter, message)
+				}
+				if !rematchStatusIncludesVote(message, "Alice") {
+					t.Fatalf("observer %d status missing per-player vote details: %+v", observer, message)
+				}
+			}
+		}
+	}
+
+	for index, client := range clients {
+		message := readTypedMessage(t, client, "state_update")
+		if message["status"] != "in_progress" {
+			t.Fatalf("client %d expected rematch state update, got %+v", index, message)
+		}
+		if got := len(message["your_hand"].([]any)); got != 13 {
+			t.Fatalf("client %d got %d rematch cards, want 13", index, got)
+		}
+	}
+}
+
+func TestWebSocketDisconnectCancelsPendingRematch(t *testing.T) {
+	server := NewGameServer("test-secret")
+	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))
+	defer httpServer.Close()
+
+	clients := connectPlayers(t, httpServer.URL, "test-secret", "room-rematch-cancel", []string{"Alice", "Bob", "Carol", "Dave"})
+	defer closeClients(clients)
+	readInitialUpdatesAndFindStarter(t, clients)
+	forceGameOverRoom(t, server.rooms["room-rematch-cancel"])
+	server.rooms["room-rematch-cancel"].broadcastGameOver()
+	for _, client := range clients {
+		readTypedMessage(t, client, "game_over")
+	}
+
+	if err := clients[0].WriteJSON(map[string]any{"type": "rematch_vote"}); err != nil {
+		t.Fatalf("write first rematch vote: %v", err)
+	}
+	for _, client := range clients {
+		readTypedMessage(t, client, "rematch_status")
+	}
+
+	if err := clients[1].Close(); err != nil {
+		t.Fatalf("close rematch voter: %v", err)
+	}
+
+	for index, client := range clients[2:] {
+		message := readTypedMessage(t, client, "rematch_cancelled")
+		if message["type"] != "rematch_cancelled" {
+			t.Fatalf("observer %d expected rematch cancellation, got %+v", index, message)
+		}
+	}
+}
+
 func TestWebSocketUnknownMessageTypeReturnsTypeError(t *testing.T) {
 	server := NewGameServer("test-secret")
 	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))
@@ -336,6 +411,31 @@ func readInitialUpdatesAndFindStarter(t *testing.T, clients []*websocket.Conn) i
 		t.Fatal("no player received seven of spades")
 	}
 	return starter
+}
+
+func forceGameOverRoom(t *testing.T, room *room) {
+	t.Helper()
+	room.mu.Lock()
+	defer room.mu.Unlock()
+	room.state = game.NewGameState()
+	room.state.FaceDown[0] = []game.Card{{Suit: game.Clubs, Rank: game.Five}}
+	room.state.FaceDown[1] = []game.Card{{Suit: game.Hearts, Rank: game.Five}}
+	room.state.FaceDown[2] = []game.Card{{Suit: game.Diamonds, Rank: game.Jack}}
+	room.state.FaceDown[3] = []game.Card{{Suit: game.Spades, Rank: game.King}}
+}
+
+func rematchStatusIncludesVote(message map[string]any, displayName string) bool {
+	players, ok := message["players"].([]any)
+	if !ok {
+		return false
+	}
+	for _, rawPlayer := range players {
+		player := rawPlayer.(map[string]any)
+		if player["display_name"] == displayName {
+			return player["voted"] == true
+		}
+	}
+	return false
 }
 
 func connectPlayers(t *testing.T, baseURL, secret, roomID string, names []string) []*websocket.Conn {

--- a/web/src/hooks/useGameSocket.ts
+++ b/web/src/hooks/useGameSocket.ts
@@ -34,6 +34,7 @@ type RematchStatusMessage = {
   type: 'rematch_status'
   votes: number
   total: number
+  players?: Array<{ display_name: string; voted: boolean }>
 }
 
 type PlayerConnectionMessage = {
@@ -246,6 +247,8 @@ function handleMessage(
     setters.setTurnEndsAt(message.turn_ends_at ?? null)
     setters.setGameOver(false)
     setters.setResults([])
+    setters.setRematchVotes(0)
+    setters.setRematchTotal(4)
     return
   }
 
@@ -260,6 +263,7 @@ function handleMessage(
       faceDownCount: result.faceDownCards.length,
       tone: playerTone(index),
       winner: result.winner,
+      votedRematch: false,
     })))
     return
   }
@@ -267,6 +271,10 @@ function handleMessage(
   if (message.type === 'rematch_status') {
     setters.setRematchVotes(message.votes)
     setters.setRematchTotal(message.total)
+    setters.setPlayers((current) => current.map((player) => ({
+      ...player,
+      votedRematch: Boolean(message.players?.some((vote) => vote.display_name === player.name && vote.voted)),
+    })))
     return
   }
 
@@ -287,6 +295,8 @@ function handleMessage(
   }
 
   if (message.type === 'rematch_cancelled') {
+    setters.setRematchVotes(0)
+    setters.setPlayers((current) => current.map((player) => ({ ...player, votedRematch: false })))
     setters.setToasts((current) => [
       { tone: 'warn', title: 'Rematch cancelled', body: 'A player left before all votes were in.' },
       ...current,

--- a/web/src/pages/GamePage.test.tsx
+++ b/web/src/pages/GamePage.test.tsx
@@ -185,3 +185,31 @@ test('renders game-over scores with revealed penalty cards and shared winners', 
   fireEvent.click(screen.getByRole('button', { name: /Vote rematch/i }))
   expect(sendRematchVote).toHaveBeenCalledOnce()
 })
+
+test('shows per-player rematch vote status on the results screen', () => {
+  vi.mocked(useGameSocket).mockReturnValue({
+    ...liveState,
+    gameOver: true,
+    rematchVotes: 2,
+    rematchTotal: 4,
+    results: [
+      { player: 'You', rank: 1, penalty: 5, winner: true, faceDownCards: [] },
+      { player: 'Budi', rank: 2, penalty: 8, winner: false, faceDownCards: [] },
+    ],
+    players: [
+      { name: 'You', initials: 'YU', cardsLeft: 0, faceDownCount: 0, tone: 'green', winner: true, votedRematch: true },
+      { name: 'Budi', initials: 'BU', cardsLeft: 0, faceDownCount: 0, tone: 'gold', votedRematch: false },
+      { name: 'Santi', initials: 'SA', cardsLeft: 0, faceDownCount: 0, tone: 'dark', votedRematch: true },
+      { name: 'Dave', initials: 'DA', cardsLeft: 0, faceDownCount: 0, tone: 'red', votedRematch: false },
+    ],
+  })
+
+  renderGame()
+
+  const voteStatus = screen.getByLabelText('Rematch vote status')
+  expect(voteStatus).toHaveTextContent('You')
+  expect(voteStatus).toHaveTextContent('Budi')
+  expect(screen.getByText('2 / 4 voted')).toBeInTheDocument()
+  expect(screen.getAllByText('Voted')).toHaveLength(2)
+  expect(screen.getAllByText('Waiting')).toHaveLength(2)
+})

--- a/web/src/pages/GamePage.tsx
+++ b/web/src/pages/GamePage.tsx
@@ -183,6 +183,14 @@ function GameOverPanel({ roomId, game }: { roomId: string | undefined; game: Gam
             <div className="h-full rounded-full bg-spade-gold-light" style={{ width: `${rematchProgress}%` }} />
           </div>
           <p className="mt-2 font-mono text-xs text-spade-gold-light">{game.rematchVotes} / {game.rematchTotal} voted</p>
+          <div className="mt-4 grid gap-2" aria-label="Rematch vote status">
+            {game.players.map((player) => (
+              <div key={player.name} className="flex items-center justify-between gap-3 rounded-spade-md border border-spade-cream/10 bg-spade-bg/55 px-3 py-2">
+                <span className="truncate text-sm text-spade-cream">{player.name}</span>
+                <Badge tone={player.votedRematch ? 'playing' : 'waiting'}>{player.votedRematch ? 'Voted' : 'Waiting'}</Badge>
+              </div>
+            ))}
+          </div>
         </div>
       </div>
     </SectionPanel>


### PR DESCRIPTION
Closes #17

## Summary
Implemented rematch voting after game over so the same room can restart once all four players opt in, and cancellation is broadcast if someone disconnects before consensus.

## Changes
- Added WebSocket `rematch_vote` handling, `rematch_status` broadcasts with per-player vote state, and `rematch_cancelled` broadcasts.
- Added integration coverage for four votes triggering a new deal and disconnect cancellation.
- Updated the results screen to show per-player rematch vote status using the existing Seven Spade panel/badge styling.
- Documented the expanded `rematch_status` payload.

## Decisions
- Votes are tracked by seated player index and reset whenever game over is broadcast, a rematch starts, or a pending rematch is cancelled.
- The final fourth vote skips an extra `rematch_status` event and directly broadcasts the fresh `state_update` for the new deal.