### PR TITLE
Game history

### DIFF
--- a/.sandcastle/gh-issue-resolver.prompt.md
+++ b/.sandcastle/gh-issue-resolver.prompt.md
@@ -19,7 +19,8 @@ You are an autonomous software engineer. Your task is to resolve a GitHub issue 
 ---
 
 ### 3. Set Up an Isolated Workspace
-- Create a new Git branch for this issue.
+- Start from the latest `main` — fetch the remote and ensure your local `main` is up-to-date before branching. Rebase or merge `origin/main` as needed to avoid starting from a stale base.
+- Create a new Git branch for this issue from the updated `main`.
 - Branch naming convention: `copilot/{issue_id}-{slug}`
   - `{issue_id}` = the numeric GitHub issue ID
   - `{slug}` = a short, lowercase, hyphen-separated description (e.g., `fix-login-timeout`)

--- a/.sandcastle/implement-prompt.md
+++ b/.sandcastle/implement-prompt.md
@@ -30,6 +30,8 @@ For frontend work in `web/`, read @design/design_system.html before implementati
 
 # EXECUTION
 
+Before starting implementation, ensure your branch is based on the latest `main` — fetch the remote and rebase onto `origin/main` (or merge if rebase conflicts are too complex). Do not start implementing against a stale base.
+
 If applicable, use RGR to complete the task.
 
 1. RED: write one test

--- a/.sandcastle/implement-prompt.md
+++ b/.sandcastle/implement-prompt.md
@@ -12,6 +12,15 @@ Work on branch {{BRANCH}}. Make commits and run tests.
 
 # CONTEXT
 
+First, ensure you have the latest `main`:
+
+!`git fetch origin main && git checkout main && git pull origin main`
+
+Then create and switch to branch {{BRANCH}} off the latest `main`.
+If the branch already exists, switch to it and rebase onto the latest `main` to stay up to date:
+
+!`git checkout {{BRANCH}} 2>/dev/null && git rebase main || git checkout -b {{BRANCH}}`
+
 Here are the last 10 commits:
 
 <recent-commits>

--- a/services/api/history.go
+++ b/services/api/history.go
@@ -48,20 +48,28 @@ func SaveGame(db *sql.DB, result GameResult) (uuid.UUID, error) {
 	if err != nil {
 		return uuid.Nil, fmt.Errorf("begin save game: %w", err)
 	}
-	defer tx.Rollback()
+	committed := false
+	defer func() {
+		if committed {
+			return
+		}
+		if err := tx.Rollback(); err != nil {
+			log.Printf("rollback save game: %v", err)
+		}
+	}()
 
 	gameID := uuid.New()
 	if _, err := tx.Exec(`INSERT INTO games (id, room_id, started_at, finished_at) VALUES ($1, $2, $3, $4)`, gameID, result.RoomID, result.StartedAt, result.FinishedAt); err != nil {
 		return uuid.Nil, fmt.Errorf("insert game: %w", err)
 	}
 	for _, player := range result.Players {
-		var userID any
+		var userID *uuid.UUID
 		if player.UserID != "" {
 			parsed, err := uuid.Parse(player.UserID)
 			if err != nil {
 				return uuid.Nil, fmt.Errorf("parse player user id: %w", err)
 			}
-			userID = parsed
+			userID = &parsed
 		}
 		_, err := tx.Exec(`
 			INSERT INTO game_players (game_id, user_id, display_name, penalty_points, rank, is_winner)
@@ -74,6 +82,7 @@ func SaveGame(db *sql.DB, result GameResult) (uuid.UUID, error) {
 	if err := tx.Commit(); err != nil {
 		return uuid.Nil, fmt.Errorf("commit save game: %w", err)
 	}
+	committed = true
 	return gameID, nil
 }
 

--- a/services/api/history.go
+++ b/services/api/history.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type GameResult struct {
+	RoomID     string             `json:"room_id"`
+	StartedAt  time.Time          `json:"started_at"`
+	FinishedAt time.Time          `json:"finished_at"`
+	Players    []GameResultPlayer `json:"players"`
+}
+
+type GameResultPlayer struct {
+	UserID        string `json:"user_id,omitempty"`
+	DisplayName   string `json:"display_name"`
+	PenaltyPoints int    `json:"penalty_points"`
+	Rank          int    `json:"rank"`
+	IsWinner      bool   `json:"is_winner"`
+}
+
+type historyGameResponse struct {
+	GameID        string `json:"game_id"`
+	RoomID        string `json:"room_id"`
+	StartedAt     string `json:"started_at"`
+	FinishedAt    string `json:"finished_at"`
+	PenaltyPoints int    `json:"penalty_points"`
+	Rank          int    `json:"rank"`
+	IsWinner      bool   `json:"is_winner"`
+}
+
+type historyResponse struct {
+	Games []historyGameResponse `json:"games"`
+	Total int                   `json:"total"`
+	Page  int                   `json:"page"`
+}
+
+func SaveGame(db *sql.DB, result GameResult) (uuid.UUID, error) {
+	tx, err := db.Begin()
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("begin save game: %w", err)
+	}
+	defer tx.Rollback()
+
+	gameID := uuid.New()
+	if _, err := tx.Exec(`INSERT INTO games (id, room_id, started_at, finished_at) VALUES ($1, $2, $3, $4)`, gameID, result.RoomID, result.StartedAt, result.FinishedAt); err != nil {
+		return uuid.Nil, fmt.Errorf("insert game: %w", err)
+	}
+	for _, player := range result.Players {
+		var userID any
+		if player.UserID != "" {
+			parsed, err := uuid.Parse(player.UserID)
+			if err != nil {
+				return uuid.Nil, fmt.Errorf("parse player user id: %w", err)
+			}
+			userID = parsed
+		}
+		_, err := tx.Exec(`
+			INSERT INTO game_players (game_id, user_id, display_name, penalty_points, rank, is_winner)
+			VALUES ($1, $2, $3, $4, $5, $6)
+		`, gameID, userID, player.DisplayName, player.PenaltyPoints, player.Rank, player.IsWinner)
+		if err != nil {
+			return uuid.Nil, fmt.Errorf("insert game player: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return uuid.Nil, fmt.Errorf("commit save game: %w", err)
+	}
+	return gameID, nil
+}
+
+func historyHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		claims, ok := claimsFromContext(r.Context())
+		if !ok {
+			writeError(w, http.StatusUnauthorized, "Authentication required")
+			return
+		}
+		userID, err := uuid.Parse(claims.Sub)
+		if err != nil || claims.IsGuest {
+			writeError(w, http.StatusUnauthorized, "Logged-in user required")
+			return
+		}
+
+		page := positiveQueryInt(r, "page", 1)
+		perPage := positiveQueryInt(r, "per_page", 10)
+		if perPage > 50 {
+			perPage = 50
+		}
+		games, total, err := GetPlayerHistory(db, userID, page, perPage)
+		if err != nil {
+			log.Printf("historyHandler: GetPlayerHistory failed: %v", err)
+			writeError(w, http.StatusInternalServerError, "Failed to load history")
+			return
+		}
+		writeJSON(w, http.StatusOK, historyResponse{Games: games, Total: total, Page: page})
+	}
+}
+
+func GetPlayerHistory(db *sql.DB, userID uuid.UUID, page int, perPage int) ([]historyGameResponse, int, error) {
+	var total int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM game_players WHERE user_id = $1`, userID).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count history: %w", err)
+	}
+
+	offset := (page - 1) * perPage
+	rows, err := db.Query(`
+		SELECT g.id, g.room_id, g.started_at, g.finished_at, gp.penalty_points, gp.rank, gp.is_winner
+		FROM game_players gp
+		JOIN games g ON g.id = gp.game_id
+		WHERE gp.user_id = $1
+		ORDER BY g.finished_at DESC
+		LIMIT $2 OFFSET $3
+	`, userID, perPage, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("query history: %w", err)
+	}
+	defer rows.Close()
+
+	games := []historyGameResponse{}
+	for rows.Next() {
+		var game historyGameResponse
+		var startedAt time.Time
+		var finishedAt time.Time
+		if err := rows.Scan(&game.GameID, &game.RoomID, &startedAt, &finishedAt, &game.PenaltyPoints, &game.Rank, &game.IsWinner); err != nil {
+			return nil, 0, fmt.Errorf("scan history: %w", err)
+		}
+		game.StartedAt = startedAt.UTC().Format(time.RFC3339)
+		game.FinishedAt = finishedAt.UTC().Format(time.RFC3339)
+		games = append(games, game)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate history: %w", err)
+	}
+	return games, total, nil
+}
+
+func saveGameHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var result GameResult
+		if err := json.NewDecoder(r.Body).Decode(&result); err != nil {
+			writeError(w, http.StatusBadRequest, "Invalid request body")
+			return
+		}
+		gameID, err := SaveGame(db, result)
+		if err != nil {
+			log.Printf("saveGameHandler: SaveGame failed: %v", err)
+			writeError(w, http.StatusInternalServerError, "Failed to save game")
+			return
+		}
+		writeJSON(w, http.StatusCreated, map[string]string{"game_id": gameID.String()})
+	}
+}
+
+func positiveQueryInt(r *http.Request, key string, fallback int) int {
+	value, err := strconv.Atoi(r.URL.Query().Get(key))
+	if err != nil || value < 1 {
+		return fallback
+	}
+	return value
+}

--- a/services/api/history_test.go
+++ b/services/api/history_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestHistoryHandlerReturnsOnlyAuthenticatedPlayersGames(t *testing.T) {
+	db := setupRoomsTestDB(t)
+	defer db.Close()
+
+	userID := createTestUser(t, db, "winner@example.com", "Winner")
+	otherUserID := createTestUser(t, db, "other@example.com", "Other")
+	roomID := uuid.New()
+	finishedAt := time.Now().UTC()
+
+	result := GameResult{
+		RoomID:     roomID.String(),
+		StartedAt:  finishedAt.Add(-20 * time.Minute),
+		FinishedAt: finishedAt,
+		Players: []GameResultPlayer{
+			{UserID: userID.String(), DisplayName: "Winner", PenaltyPoints: 4, Rank: 1, IsWinner: true},
+			{UserID: otherUserID.String(), DisplayName: "Other", PenaltyPoints: 11, Rank: 2, IsWinner: false},
+			{DisplayName: "Guest", PenaltyPoints: 15, Rank: 3, IsWinner: false},
+		},
+	}
+	if _, err := SaveGame(db, result); err != nil {
+		t.Fatalf("SaveGame: %v", err)
+	}
+
+	req := authedRequest(http.MethodGet, "/history?page=1&per_page=10", nil, userID, "Winner")
+	rec := httptest.NewRecorder()
+	historyHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	var response historyResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if response.Total != 1 || response.Page != 1 || len(response.Games) != 1 {
+		t.Fatalf("unexpected history response: %+v", response)
+	}
+	game := response.Games[0]
+	if game.RoomID != roomID.String() || game.PenaltyPoints != 4 || game.Rank != 1 || !game.IsWinner {
+		t.Fatalf("unexpected game history row: %+v", game)
+	}
+}

--- a/services/api/main.go
+++ b/services/api/main.go
@@ -106,12 +106,14 @@ func main() {
 	mux.HandleFunc("POST /login", loginHandler(db, jwtSecret))
 	mux.HandleFunc("POST /refresh", refreshHandler(db, jwtSecret))
 	mux.HandleFunc("POST /auth/telegram", telegramAuthHandler(db, jwtSecret, os.Getenv("TELEGRAM_BOT_TOKEN")))
+	mux.HandleFunc("POST /internal/games", saveGameHandler(db))
 
 	// Room endpoints (authenticated)
 	mux.HandleFunc("POST /rooms", requireAuth(jwtSecret, createRoomHandler(db)))
 	mux.HandleFunc("GET /rooms", listPublicRoomsHandler(db))
 	mux.HandleFunc("POST /rooms/{code}/join", requireAuth(jwtSecret, joinRoomHandler(db)))
 	mux.HandleFunc("GET /rooms/{id}", getRoomHandler(db))
+	mux.HandleFunc("GET /history", requireAuth(jwtSecret, historyHandler(db)))
 
 	registerOAuthRoutes(mux, db, jwtSecret)
 

--- a/services/api/migrations/003_game_history.sql
+++ b/services/api/migrations/003_game_history.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS games (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    room_id TEXT NOT NULL,
+    started_at TIMESTAMP NOT NULL,
+    finished_at TIMESTAMP NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS game_players (
+    game_id UUID NOT NULL REFERENCES games(id) ON DELETE CASCADE,
+    user_id UUID NULL REFERENCES users(id) ON DELETE SET NULL,
+    display_name VARCHAR(50) NOT NULL,
+    penalty_points INTEGER NOT NULL,
+    rank INTEGER NOT NULL,
+    is_winner BOOLEAN NOT NULL,
+    PRIMARY KEY (game_id, display_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_games_finished_at ON games(finished_at DESC);
+CREATE INDEX IF NOT EXISTS idx_game_players_user_id ON game_players(user_id);

--- a/services/ws/server.go
+++ b/services/ws/server.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -19,6 +22,7 @@ type GameServer struct {
 	jwtSecret         string
 	rooms             map[string]*room
 	store             stateStore
+	gameHistory       gameHistoryStore
 	turnTimerDuration time.Duration
 	mu                sync.Mutex
 	upgrader          websocket.Upgrader
@@ -29,7 +33,9 @@ type room struct {
 	players           []*player
 	state             game.GameState
 	store             stateStore
+	gameHistory       gameHistoryStore
 	started           bool
+	startedAt         time.Time
 	turnTimerDuration time.Duration
 	turnExpiresAt     time.Time
 	turnTimer         *time.Timer
@@ -41,6 +47,30 @@ type stateStore interface {
 	Save(roomID string, state game.GameState)
 }
 
+type gameHistoryStore interface {
+	SaveGame(result savedGameResult) error
+}
+
+type savedGameResult struct {
+	RoomID     string            `json:"room_id"`
+	StartedAt  time.Time         `json:"started_at"`
+	FinishedAt time.Time         `json:"finished_at"`
+	Players    []savedGamePlayer `json:"players"`
+}
+
+type savedGamePlayer struct {
+	UserID        string `json:"user_id,omitempty"`
+	DisplayName   string `json:"display_name"`
+	PenaltyPoints int    `json:"penalty_points"`
+	Rank          int    `json:"rank"`
+	IsWinner      bool   `json:"is_winner"`
+}
+
+type apiGameHistoryStore struct {
+	url    string
+	client *http.Client
+}
+
 type memoryStateStore struct {
 	mu     sync.Mutex
 	states map[string]game.GameState
@@ -49,6 +79,7 @@ type memoryStateStore struct {
 type player struct {
 	sub          string
 	displayName  string
+	isGuest      bool
 	index        int
 	conn         *websocket.Conn
 	disconnected bool
@@ -90,13 +121,34 @@ func NewGameServerWithStateStore(jwtSecret string, store stateStore) *GameServer
 }
 
 func NewGameServerWithOptions(jwtSecret string, store stateStore, turnTimerDuration time.Duration) *GameServer {
+	historyStore := gameHistoryStore(nil)
+	if apiURL := strings.TrimRight(os.Getenv("API_URL"), "/"); apiURL != "" {
+		historyStore = &apiGameHistoryStore{url: apiURL + "/internal/games", client: &http.Client{Timeout: 5 * time.Second}}
+	}
 	return &GameServer{
 		jwtSecret:         jwtSecret,
 		rooms:             map[string]*room{},
 		store:             store,
+		gameHistory:       historyStore,
 		turnTimerDuration: turnTimerDuration,
 		upgrader:          websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }},
 	}
+}
+
+func (store *apiGameHistoryStore) SaveGame(result savedGameResult) error {
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+	resp, err := store.client.Post(store.url, "application/json", bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("save game returned status %d", resp.StatusCode)
+	}
+	return nil
 }
 
 func newMemoryStateStore() *memoryStateStore {
@@ -183,7 +235,7 @@ func (server *GameServer) joinRoom(roomID string, claims *tokenClaims, conn *web
 	server.mu.Lock()
 	gameRoom := server.rooms[roomID]
 	if gameRoom == nil {
-		gameRoom = &room{id: roomID, store: server.store, turnTimerDuration: server.turnTimerDuration}
+		gameRoom = &room{id: roomID, store: server.store, gameHistory: server.gameHistory, turnTimerDuration: server.turnTimerDuration}
 		server.rooms[roomID] = gameRoom
 	}
 	server.mu.Unlock()
@@ -207,7 +259,7 @@ func (server *GameServer) joinRoom(roomID string, claims *tokenClaims, conn *web
 	if len(gameRoom.players) >= game.PlayerCount {
 		return nil, nil, false, fmt.Errorf("room is full")
 	}
-	player := &player{sub: claims.Sub, displayName: claims.DisplayName, index: len(gameRoom.players), conn: conn}
+	player := &player{sub: claims.Sub, displayName: claims.DisplayName, isGuest: claims.IsGuest, index: len(gameRoom.players), conn: conn}
 	gameRoom.players = append(gameRoom.players, player)
 	startedNow := false
 	if len(gameRoom.players) == game.PlayerCount {
@@ -215,6 +267,7 @@ func (server *GameServer) joinRoom(roomID string, claims *tokenClaims, conn *web
 		gameRoom.state = state
 		gameRoom.state.CurrentPlayer = starter
 		gameRoom.started = true
+		gameRoom.startedAt = time.Now().UTC()
 		startedNow = true
 		gameRoom.store.Save(roomID, gameRoom.state)
 		gameRoom.startTurnTimerLocked()
@@ -284,6 +337,7 @@ func (room *room) handleMessage(player *player, message clientMessage) {
 	room.mu.Unlock()
 
 	if gameOver {
+		room.saveGameResult()
 		room.broadcastGameOver()
 		return
 	}
@@ -329,6 +383,7 @@ func (room *room) handleTurnTimerExpired(token int) {
 	room.mu.Unlock()
 
 	if gameOver {
+		room.saveGameResult()
 		room.broadcastGameOver()
 		return
 	}
@@ -433,6 +488,47 @@ func (room *room) broadcastGameOver() {
 	for _, player := range players {
 		player.send(message)
 	}
+}
+
+func (room *room) saveGameResult() {
+	if room == nil || room.gameHistory == nil {
+		return
+	}
+	room.mu.Lock()
+	result := room.savedResultLocked(time.Now().UTC())
+	store := room.gameHistory
+	room.mu.Unlock()
+	if err := store.SaveGame(result); err != nil {
+		log.Printf("save game result: %v", err)
+	}
+}
+
+func (room *room) savedResultLocked(finishedAt time.Time) savedGameResult {
+	scores := game.CalculateScores(room.state)
+	sortedScores := append([]int(nil), scores[:]...)
+	sort.Ints(sortedScores)
+	ranksByScore := competitionRanks(sortedScores)
+	lowest := sortedScores[0]
+	players := make([]savedGamePlayer, 0, len(room.players))
+	for _, player := range room.players {
+		score := scores[player.index]
+		userID := player.sub
+		if player.isGuest {
+			userID = ""
+		}
+		players = append(players, savedGamePlayer{
+			UserID:        userID,
+			DisplayName:   player.displayName,
+			PenaltyPoints: score,
+			Rank:          ranksByScore[score],
+			IsWinner:      score == lowest,
+		})
+	}
+	startedAt := room.startedAt
+	if startedAt.IsZero() {
+		startedAt = finishedAt
+	}
+	return savedGameResult{RoomID: room.id, StartedAt: startedAt, FinishedAt: finishedAt, Players: players}
 }
 
 func (room *room) results() []map[string]any {

--- a/services/ws/server.go
+++ b/services/ws/server.go
@@ -504,14 +504,10 @@ func (room *room) saveGameResult() {
 }
 
 func (room *room) savedResultLocked(finishedAt time.Time) savedGameResult {
-	scores := game.CalculateScores(room.state)
-	sortedScores := append([]int(nil), scores[:]...)
-	sort.Ints(sortedScores)
-	ranksByScore := competitionRanks(sortedScores)
-	lowest := sortedScores[0]
+	scoredPlayers := room.scoredPlayersLocked()
 	players := make([]savedGamePlayer, 0, len(room.players))
-	for _, player := range room.players {
-		score := scores[player.index]
+	for _, scoredPlayer := range scoredPlayers {
+		player := scoredPlayer.player
 		userID := player.sub
 		if player.isGuest {
 			userID = ""
@@ -519,9 +515,9 @@ func (room *room) savedResultLocked(finishedAt time.Time) savedGameResult {
 		players = append(players, savedGamePlayer{
 			UserID:        userID,
 			DisplayName:   player.displayName,
-			PenaltyPoints: score,
-			Rank:          ranksByScore[score],
-			IsWinner:      score == lowest,
+			PenaltyPoints: scoredPlayer.score,
+			Rank:          scoredPlayer.rank,
+			IsWinner:      scoredPlayer.isWinner,
 		})
 	}
 	startedAt := room.startedAt
@@ -532,23 +528,40 @@ func (room *room) savedResultLocked(finishedAt time.Time) savedGameResult {
 }
 
 func (room *room) results() []map[string]any {
+	scoredPlayers := room.scoredPlayersLocked()
+	results := make([]map[string]any, 0, len(scoredPlayers))
+	for _, scoredPlayer := range scoredPlayers {
+		player := scoredPlayer.player
+		results = append(results, map[string]any{
+			"display_name":   player.displayName,
+			"facedown_cards": revealedFaceDownCards(room.state, player.index),
+			"penalty_points": scoredPlayer.score,
+			"rank":           scoredPlayer.rank,
+			"is_winner":      scoredPlayer.isWinner,
+		})
+	}
+	return results
+}
+
+type scoredPlayer struct {
+	player   *player
+	score    int
+	rank     int
+	isWinner bool
+}
+
+func (room *room) scoredPlayersLocked() []scoredPlayer {
 	scores := game.CalculateScores(room.state)
 	sortedScores := append([]int(nil), scores[:]...)
 	sort.Ints(sortedScores)
 	ranksByScore := competitionRanks(sortedScores)
 	lowest := sortedScores[0]
-	results := make([]map[string]any, 0, len(room.players))
+	scoredPlayers := make([]scoredPlayer, 0, len(room.players))
 	for _, player := range room.players {
 		score := scores[player.index]
-		results = append(results, map[string]any{
-			"display_name":   player.displayName,
-			"facedown_cards": revealedFaceDownCards(room.state, player.index),
-			"penalty_points": score,
-			"rank":           ranksByScore[score],
-			"is_winner":      score == lowest,
-		})
+		scoredPlayers = append(scoredPlayers, scoredPlayer{player: player, score: score, rank: ranksByScore[score], isWinner: score == lowest})
 	}
-	return results
+	return scoredPlayers
 }
 
 func competitionRanks(sortedScores []int) map[int]int {

--- a/services/ws/server.go
+++ b/services/ws/server.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -19,6 +22,7 @@ type GameServer struct {
 	jwtSecret         string
 	rooms             map[string]*room
 	store             stateStore
+	gameHistory       gameHistoryStore
 	turnTimerDuration time.Duration
 	mu                sync.Mutex
 	upgrader          websocket.Upgrader
@@ -29,7 +33,9 @@ type room struct {
 	players           []*player
 	state             game.GameState
 	store             stateStore
+	gameHistory       gameHistoryStore
 	started           bool
+	startedAt         time.Time
 	turnTimerDuration time.Duration
 	turnExpiresAt     time.Time
 	turnTimer         *time.Timer
@@ -42,6 +48,30 @@ type stateStore interface {
 	Save(roomID string, state game.GameState)
 }
 
+type gameHistoryStore interface {
+	SaveGame(result savedGameResult) error
+}
+
+type savedGameResult struct {
+	RoomID     string            `json:"room_id"`
+	StartedAt  time.Time         `json:"started_at"`
+	FinishedAt time.Time         `json:"finished_at"`
+	Players    []savedGamePlayer `json:"players"`
+}
+
+type savedGamePlayer struct {
+	UserID        string `json:"user_id,omitempty"`
+	DisplayName   string `json:"display_name"`
+	PenaltyPoints int    `json:"penalty_points"`
+	Rank          int    `json:"rank"`
+	IsWinner      bool   `json:"is_winner"`
+}
+
+type apiGameHistoryStore struct {
+	url    string
+	client *http.Client
+}
+
 type memoryStateStore struct {
 	mu     sync.Mutex
 	states map[string]game.GameState
@@ -50,6 +80,7 @@ type memoryStateStore struct {
 type player struct {
 	sub          string
 	displayName  string
+	isGuest      bool
 	index        int
 	conn         *websocket.Conn
 	disconnected bool
@@ -94,13 +125,34 @@ func NewGameServerWithStateStore(jwtSecret string, store stateStore) *GameServer
 }
 
 func NewGameServerWithOptions(jwtSecret string, store stateStore, turnTimerDuration time.Duration) *GameServer {
+	historyStore := gameHistoryStore(nil)
+	if apiURL := strings.TrimRight(os.Getenv("API_URL"), "/"); apiURL != "" {
+		historyStore = &apiGameHistoryStore{url: apiURL + "/internal/games", client: &http.Client{Timeout: 5 * time.Second}}
+	}
 	return &GameServer{
 		jwtSecret:         jwtSecret,
 		rooms:             map[string]*room{},
 		store:             store,
+		gameHistory:       historyStore,
 		turnTimerDuration: turnTimerDuration,
 		upgrader:          websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }},
 	}
+}
+
+func (store *apiGameHistoryStore) SaveGame(result savedGameResult) error {
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+	resp, err := store.client.Post(store.url, "application/json", bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("save game returned status %d", resp.StatusCode)
+	}
+	return nil
 }
 
 func newMemoryStateStore() *memoryStateStore {
@@ -187,7 +239,7 @@ func (server *GameServer) joinRoom(roomID string, claims *tokenClaims, conn *web
 	server.mu.Lock()
 	gameRoom := server.rooms[roomID]
 	if gameRoom == nil {
-		gameRoom = &room{id: roomID, store: server.store, turnTimerDuration: server.turnTimerDuration, rematchVotes: map[int]bool{}}
+		gameRoom = &room{id: roomID, store: server.store, gameHistory: server.gameHistory, turnTimerDuration: server.turnTimerDuration, rematchVotes: map[int]bool{}}
 		server.rooms[roomID] = gameRoom
 	}
 	server.mu.Unlock()
@@ -211,7 +263,7 @@ func (server *GameServer) joinRoom(roomID string, claims *tokenClaims, conn *web
 	if len(gameRoom.players) >= game.PlayerCount {
 		return nil, nil, false, fmt.Errorf("room is full")
 	}
-	player := &player{sub: claims.Sub, displayName: claims.DisplayName, index: len(gameRoom.players), conn: conn}
+	player := &player{sub: claims.Sub, displayName: claims.DisplayName, isGuest: claims.IsGuest, index: len(gameRoom.players), conn: conn}
 	gameRoom.players = append(gameRoom.players, player)
 	startedNow := false
 	if len(gameRoom.players) == game.PlayerCount {
@@ -219,6 +271,7 @@ func (server *GameServer) joinRoom(roomID string, claims *tokenClaims, conn *web
 		gameRoom.state = state
 		gameRoom.state.CurrentPlayer = starter
 		gameRoom.started = true
+		gameRoom.startedAt = time.Now().UTC()
 		startedNow = true
 		gameRoom.store.Save(roomID, gameRoom.state)
 		gameRoom.startTurnTimerLocked()
@@ -299,6 +352,7 @@ func (room *room) handleMessage(player *player, message clientMessage) {
 	room.mu.Unlock()
 
 	if gameOver {
+		room.saveGameResult()
 		room.broadcastGameOver()
 		return
 	}
@@ -370,6 +424,7 @@ func (room *room) handleTurnTimerExpired(token int) {
 	room.mu.Unlock()
 
 	if gameOver {
+		room.saveGameResult()
 		room.broadcastGameOver()
 		return
 	}
@@ -520,6 +575,47 @@ func connectedPlayersLocked(players []*player) []*player {
 		}
 	}
 	return connected
+}
+
+func (room *room) saveGameResult() {
+	if room == nil || room.gameHistory == nil {
+		return
+	}
+	room.mu.Lock()
+	result := room.savedResultLocked(time.Now().UTC())
+	store := room.gameHistory
+	room.mu.Unlock()
+	if err := store.SaveGame(result); err != nil {
+		log.Printf("save game result: %v", err)
+	}
+}
+
+func (room *room) savedResultLocked(finishedAt time.Time) savedGameResult {
+	scores := game.CalculateScores(room.state)
+	sortedScores := append([]int(nil), scores[:]...)
+	sort.Ints(sortedScores)
+	ranksByScore := competitionRanks(sortedScores)
+	lowest := sortedScores[0]
+	players := make([]savedGamePlayer, 0, len(room.players))
+	for _, player := range room.players {
+		score := scores[player.index]
+		userID := player.sub
+		if player.isGuest {
+			userID = ""
+		}
+		players = append(players, savedGamePlayer{
+			UserID:        userID,
+			DisplayName:   player.displayName,
+			PenaltyPoints: score,
+			Rank:          ranksByScore[score],
+			IsWinner:      score == lowest,
+		})
+	}
+	startedAt := room.startedAt
+	if startedAt.IsZero() {
+		startedAt = finishedAt
+	}
+	return savedGameResult{RoomID: room.id, StartedAt: startedAt, FinishedAt: finishedAt, Players: players}
 }
 
 func (room *room) results() []map[string]any {

--- a/services/ws/server.go
+++ b/services/ws/server.go
@@ -591,14 +591,10 @@ func (room *room) saveGameResult() {
 }
 
 func (room *room) savedResultLocked(finishedAt time.Time) savedGameResult {
-	scores := game.CalculateScores(room.state)
-	sortedScores := append([]int(nil), scores[:]...)
-	sort.Ints(sortedScores)
-	ranksByScore := competitionRanks(sortedScores)
-	lowest := sortedScores[0]
+	scoredPlayers := room.scoredPlayersLocked()
 	players := make([]savedGamePlayer, 0, len(room.players))
-	for _, player := range room.players {
-		score := scores[player.index]
+	for _, scoredPlayer := range scoredPlayers {
+		player := scoredPlayer.player
 		userID := player.sub
 		if player.isGuest {
 			userID = ""
@@ -606,9 +602,9 @@ func (room *room) savedResultLocked(finishedAt time.Time) savedGameResult {
 		players = append(players, savedGamePlayer{
 			UserID:        userID,
 			DisplayName:   player.displayName,
-			PenaltyPoints: score,
-			Rank:          ranksByScore[score],
-			IsWinner:      score == lowest,
+			PenaltyPoints: scoredPlayer.score,
+			Rank:          scoredPlayer.rank,
+			IsWinner:      scoredPlayer.isWinner,
 		})
 	}
 	startedAt := room.startedAt
@@ -619,23 +615,40 @@ func (room *room) savedResultLocked(finishedAt time.Time) savedGameResult {
 }
 
 func (room *room) results() []map[string]any {
+	scoredPlayers := room.scoredPlayersLocked()
+	results := make([]map[string]any, 0, len(scoredPlayers))
+	for _, scoredPlayer := range scoredPlayers {
+		player := scoredPlayer.player
+		results = append(results, map[string]any{
+			"display_name":   player.displayName,
+			"facedown_cards": revealedFaceDownCards(room.state, player.index),
+			"penalty_points": scoredPlayer.score,
+			"rank":           scoredPlayer.rank,
+			"is_winner":      scoredPlayer.isWinner,
+		})
+	}
+	return results
+}
+
+type scoredPlayer struct {
+	player   *player
+	score    int
+	rank     int
+	isWinner bool
+}
+
+func (room *room) scoredPlayersLocked() []scoredPlayer {
 	scores := game.CalculateScores(room.state)
 	sortedScores := append([]int(nil), scores[:]...)
 	sort.Ints(sortedScores)
 	ranksByScore := competitionRanks(sortedScores)
 	lowest := sortedScores[0]
-	results := make([]map[string]any, 0, len(room.players))
+	scoredPlayers := make([]scoredPlayer, 0, len(room.players))
 	for _, player := range room.players {
 		score := scores[player.index]
-		results = append(results, map[string]any{
-			"display_name":   player.displayName,
-			"facedown_cards": revealedFaceDownCards(room.state, player.index),
-			"penalty_points": score,
-			"rank":           ranksByScore[score],
-			"is_winner":      score == lowest,
-		})
+		scoredPlayers = append(scoredPlayers, scoredPlayer{player: player, score: score, rank: ranksByScore[score], isWinner: score == lowest})
 	}
-	return results
+	return scoredPlayers
 }
 
 func competitionRanks(sortedScores []int) map[int]int {

--- a/services/ws/server_test.go
+++ b/services/ws/server_test.go
@@ -12,6 +12,15 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+type memoryGameHistoryStore struct {
+	results []savedGameResult
+}
+
+func (store *memoryGameHistoryStore) SaveGame(result savedGameResult) error {
+	store.results = append(store.results, result)
+	return nil
+}
+
 func TestWebSocketRoomStartsGameWhenFourthPlayerJoins(t *testing.T) {
 	server := NewGameServer("test-secret")
 	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))
@@ -303,6 +312,49 @@ func TestWebSocketBroadcastsGameOverAfterFinalMove(t *testing.T) {
 	}
 }
 
+func TestWebSocketSavesGameResultAfterFinalMove(t *testing.T) {
+	history := &memoryGameHistoryStore{}
+	server := NewGameServerWithOptions("test-secret", newMemoryStateStore(), time.Hour)
+	server.gameHistory = history
+	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))
+	defer httpServer.Close()
+
+	clients := connectPlayers(t, httpServer.URL, "test-secret", "room-save-game", []string{"Alice", "Bob", "Carol", "Dave"})
+	defer closeClients(clients)
+	readInitialUpdatesAndFindStarter(t, clients)
+
+	room := server.rooms["room-save-game"]
+	room.mu.Lock()
+	room.state = game.NewGameState()
+	room.state.Board[game.Spades] = game.SuitSequence{Low: game.Seven, High: game.Seven}
+	room.state.Hands[0] = []game.Card{{Suit: game.Spades, Rank: game.Six}}
+	room.state.FaceDown[0] = []game.Card{{Suit: game.Clubs, Rank: game.Four}}
+	room.state.FaceDown[1] = []game.Card{{Suit: game.Hearts, Rank: game.Nine}}
+	room.state.FaceDown[2] = []game.Card{{Suit: game.Diamonds, Rank: game.Ten}}
+	room.state.FaceDown[3] = []game.Card{{Suit: game.Spades, Rank: game.King}}
+	room.state.CurrentPlayer = 0
+	room.mu.Unlock()
+
+	if err := clients[0].WriteJSON(map[string]any{"type": "play_card", "suit": "spades", "rank": "6"}); err != nil {
+		t.Fatalf("write final move: %v", err)
+	}
+	readTypedMessage(t, clients[0], "game_over")
+
+	if len(history.results) != 1 {
+		t.Fatalf("expected one saved game result, got %+v", history.results)
+	}
+	result := history.results[0]
+	if result.RoomID != "room-save-game" || result.StartedAt.IsZero() || result.FinishedAt.IsZero() {
+		t.Fatalf("saved result missing game metadata: %+v", result)
+	}
+	if len(result.Players) != 4 {
+		t.Fatalf("expected four saved players, got %+v", result.Players)
+	}
+	if result.Players[0].UserID != "Alice-id" || result.Players[0].DisplayName != "Alice" || result.Players[0].PenaltyPoints != 4 || result.Players[0].Rank != 1 || !result.Players[0].IsWinner {
+		t.Fatalf("unexpected saved Alice result: %+v", result.Players[0])
+	}
+}
+
 func TestWebSocketUnknownMessageTypeReturnsTypeError(t *testing.T) {
 	server := NewGameServer("test-secret")
 	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))
@@ -362,7 +414,7 @@ func signTestToken(t *testing.T, secret, displayName string) string {
 	claims := jwt.MapClaims{
 		"sub":          displayName + "-id",
 		"display_name": displayName,
-		"is_guest":     true,
+		"is_guest":     false,
 		"exp":          time.Now().Add(time.Hour).Unix(),
 	}
 	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(secret))

--- a/services/ws/server_test.go
+++ b/services/ws/server_test.go
@@ -12,6 +12,15 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+type memoryGameHistoryStore struct {
+	results []savedGameResult
+}
+
+func (store *memoryGameHistoryStore) SaveGame(result savedGameResult) error {
+	store.results = append(store.results, result)
+	return nil
+}
+
 func TestWebSocketRoomStartsGameWhenFourthPlayerJoins(t *testing.T) {
 	server := NewGameServer("test-secret")
 	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))
@@ -378,6 +387,49 @@ func TestWebSocketDisconnectCancelsPendingRematch(t *testing.T) {
 	}
 }
 
+func TestWebSocketSavesGameResultAfterFinalMove(t *testing.T) {
+	history := &memoryGameHistoryStore{}
+	server := NewGameServerWithOptions("test-secret", newMemoryStateStore(), time.Hour)
+	server.gameHistory = history
+	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))
+	defer httpServer.Close()
+
+	clients := connectPlayers(t, httpServer.URL, "test-secret", "room-save-game", []string{"Alice", "Bob", "Carol", "Dave"})
+	defer closeClients(clients)
+	readInitialUpdatesAndFindStarter(t, clients)
+
+	room := server.rooms["room-save-game"]
+	room.mu.Lock()
+	room.state = game.NewGameState()
+	room.state.Board[game.Spades] = game.SuitSequence{Low: game.Seven, High: game.Seven}
+	room.state.Hands[0] = []game.Card{{Suit: game.Spades, Rank: game.Six}}
+	room.state.FaceDown[0] = []game.Card{{Suit: game.Clubs, Rank: game.Four}}
+	room.state.FaceDown[1] = []game.Card{{Suit: game.Hearts, Rank: game.Nine}}
+	room.state.FaceDown[2] = []game.Card{{Suit: game.Diamonds, Rank: game.Ten}}
+	room.state.FaceDown[3] = []game.Card{{Suit: game.Spades, Rank: game.King}}
+	room.state.CurrentPlayer = 0
+	room.mu.Unlock()
+
+	if err := clients[0].WriteJSON(map[string]any{"type": "play_card", "suit": "spades", "rank": "6"}); err != nil {
+		t.Fatalf("write final move: %v", err)
+	}
+	readTypedMessage(t, clients[0], "game_over")
+
+	if len(history.results) != 1 {
+		t.Fatalf("expected one saved game result, got %+v", history.results)
+	}
+	result := history.results[0]
+	if result.RoomID != "room-save-game" || result.StartedAt.IsZero() || result.FinishedAt.IsZero() {
+		t.Fatalf("saved result missing game metadata: %+v", result)
+	}
+	if len(result.Players) != 4 {
+		t.Fatalf("expected four saved players, got %+v", result.Players)
+	}
+	if result.Players[0].UserID != "Alice-id" || result.Players[0].DisplayName != "Alice" || result.Players[0].PenaltyPoints != 4 || result.Players[0].Rank != 1 || !result.Players[0].IsWinner {
+		t.Fatalf("unexpected saved Alice result: %+v", result.Players[0])
+	}
+}
+
 func TestWebSocketUnknownMessageTypeReturnsTypeError(t *testing.T) {
 	server := NewGameServer("test-secret")
 	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))
@@ -462,7 +514,7 @@ func signTestToken(t *testing.T, secret, displayName string) string {
 	claims := jwt.MapClaims{
 		"sub":          displayName + "-id",
 		"display_name": displayName,
-		"is_guest":     true,
+		"is_guest":     false,
 		"exp":          time.Now().Add(time.Hour).Unix(),
 	}
 	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(secret))

--- a/services/ws/server_test.go
+++ b/services/ws/server_test.go
@@ -430,6 +430,33 @@ func TestWebSocketSavesGameResultAfterFinalMove(t *testing.T) {
 	}
 }
 
+func TestSavedGameResultOmitsGuestUserIDs(t *testing.T) {
+	room := &room{
+		id:        "room-guests",
+		startedAt: time.Now().UTC().Add(-15 * time.Minute),
+		players: []*player{
+			{sub: "Alice-id", displayName: "Alice", index: 0},
+			{sub: "Guest-id", displayName: "Guest", isGuest: true, index: 1},
+			{sub: "Carol-id", displayName: "Carol", index: 2},
+			{sub: "Dave-id", displayName: "Dave", index: 3},
+		},
+		state: game.NewGameState(),
+	}
+	room.state.FaceDown[0] = []game.Card{{Suit: game.Clubs, Rank: game.Four}}
+	room.state.FaceDown[1] = []game.Card{{Suit: game.Hearts, Rank: game.Nine}}
+	room.state.FaceDown[2] = []game.Card{{Suit: game.Diamonds, Rank: game.Ten}}
+	room.state.FaceDown[3] = []game.Card{{Suit: game.Spades, Rank: game.King}}
+
+	result := room.savedResultLocked(time.Now().UTC())
+
+	if result.Players[0].UserID != "Alice-id" {
+		t.Fatalf("expected authenticated player user id to be saved, got %+v", result.Players[0])
+	}
+	if result.Players[1].UserID != "" || result.Players[1].DisplayName != "Guest" {
+		t.Fatalf("expected guest player display name without user id, got %+v", result.Players[1])
+	}
+}
+
 func TestWebSocketUnknownMessageTypeReturnsTypeError(t *testing.T) {
 	server := NewGameServer("test-secret")
 	httpServer := httptest.NewServer(server.routes(testDependencyChecks()))

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 import App from './App'
 import { postGuest, postLogin, postRegister, postTelegramAuth } from './api/auth'
+import { getHistory } from './api/history'
 import { getRooms, postJoinRoom, postRoom } from './api/lobby'
 
 vi.mock('./api/auth', () => ({
@@ -39,6 +40,10 @@ vi.mock('./api/lobby', () => ({
   postJoinRoom: vi.fn(),
 }))
 
+vi.mock('./api/history', () => ({
+  getHistory: vi.fn(),
+}))
+
 beforeEach(() => {
   vi.mocked(getRooms).mockResolvedValue([
     {
@@ -63,6 +68,21 @@ beforeEach(() => {
     invite_code: 'XKQP7A',
     status: 'waiting',
     player_count: 4,
+  })
+  vi.mocked(getHistory).mockResolvedValue({
+    games: [
+      {
+        game_id: 'game-1',
+        room_id: 'XKQP7',
+        started_at: '2026-05-09T10:00:00Z',
+        finished_at: '2026-05-09T10:20:00Z',
+        penalty_points: 5,
+        rank: 1,
+        is_winner: true,
+      },
+    ],
+    total: 1,
+    page: 1,
   })
   // Pre-seed an auth token so /lobby renders without redirecting to /auth.
   localStorage.setItem('seven_spade_auth_token', 'test-token')
@@ -102,7 +122,9 @@ test('renders real top-level routes with temporary hardcoded data', async () => 
 
   renderRoute('/history')
   expect(screen.getByRole('heading', { name: /Game history/i })).toBeInTheDocument()
-  expect(screen.getByText(/XKQP7/i)).toBeInTheDocument()
+  await waitFor(() => {
+    expect(screen.getByText(/XKQP7/i)).toBeInTheDocument()
+  })
 })
 
 test('renders a single dynamic game route', () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,9 +6,11 @@ import { GamePage } from "./pages/GamePage";
 import { HistoryPage } from "./pages/HistoryPage";
 import { LobbyPage } from "./pages/LobbyPage";
 import { ResultsPage } from "./pages/ResultsPage";
+import { useAuth } from "./hooks/useAuth";
 
 function App() {
   const { pathname } = useLocation();
+  const { isAuthenticated } = useAuth();
   const hideHeader = pathname === "/auth" || pathname === "/register" || pathname === "/login" || pathname === "/auth/callback";
 
   return (
@@ -24,6 +26,26 @@ function App() {
                 Seven Spade
               </span>
             </NavLink>
+            {isAuthenticated ? (
+              <nav aria-label="Primary navigation" className="flex items-center gap-2 text-sm">
+                <NavLink
+                  to="/lobby"
+                  className={({ isActive }) =>
+                    `rounded-spade-pill px-3 py-2 ${isActive ? "bg-spade-green-mid text-spade-gold" : "text-spade-gray-2 hover:text-spade-cream"}`
+                  }
+                >
+                  Lobby
+                </NavLink>
+                <NavLink
+                  to="/history"
+                  className={({ isActive }) =>
+                    `rounded-spade-pill px-3 py-2 ${isActive ? "bg-spade-green-mid text-spade-gold" : "text-spade-gray-2 hover:text-spade-cream"}`
+                  }
+                >
+                  My Games
+                </NavLink>
+              </nav>
+            ) : null}
           </div>
         </header>
       ) : null}

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -1,59 +1,62 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
+import { ApiError } from '../api/client'
+import { getHistory, type HistoryGameDto } from '../api/history'
 import { Badge } from '../components/Badge'
 import { Button } from '../components/Button'
 import { SceneShell } from '../components/SceneShell'
-
-type HistoryGame = {
-  gameId: string
-  roomId: string
-  startedAt: string
-  finishedAt: string
-  penaltyPoints: number
-  rank: number
-  isWinner: boolean
-}
-
-const games: HistoryGame[] = [
-  {
-    gameId: 'game-1',
-    roomId: 'XKQP7',
-    startedAt: '2026-05-09T10:00:00Z',
-    finishedAt: '2026-05-09T10:20:00Z',
-    penaltyPoints: 5,
-    rank: 1,
-    isWinner: true,
-  },
-  {
-    gameId: 'game-2',
-    roomId: 'PR7A2',
-    startedAt: '2026-05-08T18:30:00Z',
-    finishedAt: '2026-05-08T18:52:00Z',
-    penaltyPoints: 24,
-    rank: 2,
-    isWinner: false,
-  },
-  {
-    gameId: 'game-3',
-    roomId: 'FNG44',
-    startedAt: '2026-05-01T21:00:00Z',
-    finishedAt: '2026-05-01T21:31:00Z',
-    penaltyPoints: 52,
-    rank: 4,
-    isWinner: false,
-  },
-]
+import { useAuth } from '../hooks/useAuth'
 
 const perPage = 2
 
 export function HistoryPage() {
   const navigate = useNavigate()
+  const { token, isAuthenticated } = useAuth()
   const [page, setPage] = useState(1)
-  const totalPages = Math.max(1, Math.ceil(games.length / perPage))
-  const visibleGames = games.slice((page - 1) * perPage, page * perPage)
+  const [games, setGames] = useState<HistoryGameDto[]>([])
+  const [total, setTotal] = useState(0)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const totalPages = Math.max(1, Math.ceil(total / perPage))
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      navigate('/auth', { replace: true })
+      return
+    }
+    let cancelled = false
+    Promise.resolve()
+      .then(() => {
+        if (cancelled) return null
+        setIsLoading(true)
+        setError(null)
+        return getHistory(token, page, perPage)
+      })
+      .then((response) => {
+        if (cancelled || response === null) return
+        setGames(response.games)
+        setTotal(response.total)
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setError(getErrorMessage(err, 'Failed to load game history'))
+      })
+      .finally(() => {
+        if (cancelled) return
+        setIsLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [isAuthenticated, navigate, page, token])
 
   return (
     <SceneShell title="Game history" eyebrow="Logged-in player results" action={<Badge tone="waiting">{`Page ${page}`}</Badge>}>
+      {error ? (
+        <div className="mb-4 rounded-spade-md border border-spade-red/50 bg-spade-red-dark/30 px-4 py-3 text-sm text-spade-cream">
+          {error}
+        </div>
+      ) : null}
       <div className="overflow-hidden rounded-spade-lg border border-spade-cream/12 bg-[#2b302d]">
         <table aria-label="Game history" className="w-full text-sm">
           <thead className="bg-spade-cream/8 text-left font-mono text-[10px] uppercase tracking-[0.06em] text-spade-gray-3">
@@ -66,22 +69,29 @@ export function HistoryPage() {
             </tr>
           </thead>
           <tbody>
-            {visibleGames.map((game) => (
-              <tr key={game.gameId} className="border-t border-spade-cream/8">
-                <td className="px-4 py-3 font-mono text-xs">{game.roomId}</td>
-                <td className="px-2 py-3 text-spade-gray-2">{formatDate(game.startedAt)}</td>
-                <td className="px-2 py-3">{game.isWinner ? 'Winner' : `Rank ${game.rank}`}</td>
-                <td className="px-2 py-3 font-mono text-spade-gold-light">{game.penaltyPoints}</td>
-                <td className="px-4 py-3 text-xs text-spade-gray-2">{formatDate(game.finishedAt)}</td>
+            {games.map((game) => (
+              <tr key={game.game_id} className="border-t border-spade-cream/8">
+                <td className="px-4 py-3 font-mono text-xs">{game.room_id}</td>
+                <td className="px-2 py-3 text-spade-gray-2">{formatDate(game.started_at)}</td>
+                <td className="px-2 py-3">{game.is_winner ? 'Winner' : `Rank ${game.rank}`}</td>
+                <td className="px-2 py-3 font-mono text-spade-gold-light">{game.penalty_points}</td>
+                <td className="px-4 py-3 text-xs text-spade-gray-2">{formatDate(game.finished_at)}</td>
               </tr>
             ))}
+            {!isLoading && games.length === 0 ? (
+              <tr className="border-t border-spade-cream/8">
+                <td colSpan={5} className="px-4 py-8 text-center text-sm text-spade-gray-2">
+                  No completed games yet.
+                </td>
+              </tr>
+            ) : null}
           </tbody>
         </table>
       </div>
 
       <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
         <p className="font-mono text-xs text-spade-gray-3">
-          {games.length} games · page {page} of {totalPages}
+          {isLoading ? 'Loading games...' : `${total} games · page ${page} of ${totalPages}`}
         </p>
         <div className="flex flex-wrap gap-2">
           <Button variant="secondary" disabled={page <= 1} onClick={() => setPage((current) => Math.max(1, current - 1))}>
@@ -95,6 +105,12 @@ export function HistoryPage() {
       </div>
     </SceneShell>
   )
+}
+
+function getErrorMessage(err: unknown, fallback: string): string {
+  if (err instanceof ApiError) return err.message
+  if (err instanceof Error) return err.message
+  return fallback
 }
 
 function formatDate(value: string): string {


### PR DESCRIPTION
Closes #16

## Summary
Persist completed Seven Spade results and expose authenticated game history so logged-in players can review past scores.

## Changes
- Added PostgreSQL game history tables and API save/history handlers.
- Added WebSocket game-over persistence through an internal API history store.
- Replaced the stub My Games page with paginated API data and authenticated nav access.
- Added backend and frontend regression coverage.

## Decisions
- Guest players are saved with display names only and no user_id.
- WebSocket history persistence is enabled when API_URL is configured and failures are logged without blocking the game_over broadcast.
- Plain go test ./... still hits the local gcc -m64 blocker; CGO_ENABLED=0 rtk go test ./... passed for both Go services.