### PR TITLE
fix(auth): treat OAuth logins as email-verified (#57)

### DIFF
--- a/services/api/internal/repository/user.go
+++ b/services/api/internal/repository/user.go
@@ -393,9 +393,12 @@ func UpsertOAuthUser(db *sql.DB, profile OAuthProfile) (*User, error) {
 			if _, serr := tx.Exec(`SAVEPOINT oauth_user_insert`); serr != nil {
 				return nil, fmt.Errorf("savepoint: %w", serr)
 			}
+			// OAuth providers authenticate the account, so the email (when
+			// present) is treated as verified — email_verified_at is stamped on
+			// create so OAuth users never see the verify-email prompt.
 			err = tx.QueryRow(`
-				INSERT INTO users (id, email, display_name, username, created_at)
-				VALUES ($1, $2, $3, $4, NOW())
+				INSERT INTO users (id, email, display_name, username, email_verified_at, created_at)
+				VALUES ($1, $2, $3, $4, NOW(), NOW())
 				RETURNING id, email, password_hash, display_name, username, created_at
 			`, newID, email, profile.DisplayName, username).
 				Scan(&user.ID, &user.Email, &user.PasswordHash, &user.DisplayName, &user.Username, &user.CreatedAt)
@@ -415,9 +418,14 @@ func UpsertOAuthUser(db *sql.DB, profile OAuthProfile) (*User, error) {
 			}
 		}
 	} else {
-		// Existing user: refresh the display name but keep their username.
+		// Existing user: refresh the display name but keep their username. Also
+		// backfill email_verified_at for accounts that linked OAuth after an
+		// unverified email/password signup (or predate this behaviour); COALESCE
+		// preserves an already-set verification timestamp.
 		err = tx.QueryRow(`
-			UPDATE users SET display_name = $1 WHERE id = $2
+			UPDATE users SET display_name = $1,
+			                 email_verified_at = COALESCE(email_verified_at, NOW())
+			WHERE id = $2
 			RETURNING id, email, password_hash, display_name, username, created_at
 		`, profile.DisplayName, userID).
 			Scan(&user.ID, &user.Email, &user.PasswordHash, &user.DisplayName, &user.Username, &user.CreatedAt)

--- a/services/api/internal/repository/user_test.go
+++ b/services/api/internal/repository/user_test.go
@@ -1,8 +1,10 @@
 package repository
 
 import (
+	"database/sql"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
@@ -87,6 +89,102 @@ func TestSearchUsersExcludesBlocked(t *testing.T) {
 
 	if _, err := SearchUsers(db, "bob", caller, 20); err != nil {
 		t.Fatalf("SearchUsers: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// UpsertOAuthUser stamps email_verified_at when linking an existing OAuth account
+// so social logins are treated as verified. The UPDATE uses COALESCE so an
+// already-set verification timestamp is preserved.
+func TestUpsertOAuthUserExistingMarksVerified(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	userID := uuid.New()
+	profile := OAuthProfile{
+		Provider:       "google",
+		ProviderUserID: "g-123",
+		Email:          "Alice@Example.com",
+		DisplayName:    "Alice",
+		AvatarURL:      "https://cdn/a.png",
+	}
+
+	mock.ExpectBegin()
+	// Provider link already exists -> existing-user path.
+	mock.ExpectQuery("SELECT user_id FROM user_providers").
+		WithArgs("google", "g-123").
+		WillReturnRows(sqlmock.NewRows([]string{"user_id"}).AddRow(userID))
+	// The UPDATE backfills email_verified_at via COALESCE.
+	mock.ExpectQuery(regexp.QuoteMeta("email_verified_at = COALESCE(email_verified_at, NOW())")).
+		WithArgs("Alice", userID).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "email", "password_hash", "display_name", "username", "created_at"}).
+			AddRow(userID, "alice@example.com", nil, "Alice", "alice", time.Now()))
+	mock.ExpectExec("INSERT INTO user_providers").
+		WithArgs(userID, "google", "g-123", "alice@example.com", "https://cdn/a.png").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	user, err := UpsertOAuthUser(db, profile)
+	if err != nil {
+		t.Fatalf("UpsertOAuthUser: %v", err)
+	}
+	if user.ID != userID {
+		t.Fatalf("user.ID = %v, want %v", user.ID, userID)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// A new OAuth user is inserted with email_verified_at set, so the verify-email
+// banner never shows for social signups.
+func TestUpsertOAuthUserNewMarksVerified(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	profile := OAuthProfile{
+		Provider:       "github",
+		ProviderUserID: "gh-7",
+		Email:          "bob@example.com",
+		DisplayName:    "Bob",
+		Username:       "bob",
+	}
+
+	mock.ExpectBegin()
+	// No provider link...
+	mock.ExpectQuery("SELECT user_id FROM user_providers").
+		WithArgs("github", "gh-7").
+		WillReturnError(sql.ErrNoRows)
+	// ...and no user with that email -> new-user path.
+	mock.ExpectQuery("SELECT id FROM users WHERE email").
+		WithArgs("bob@example.com").
+		WillReturnError(sql.ErrNoRows)
+	// Username uniqueness probe (GenerateUniqueUsername).
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("bob").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectExec("SAVEPOINT oauth_user_insert").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	// The INSERT includes email_verified_at.
+	mock.ExpectQuery(regexp.QuoteMeta("INSERT INTO users (id, email, display_name, username, email_verified_at, created_at)")).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "email", "password_hash", "display_name", "username", "created_at"}).
+			AddRow(uuid.New(), "bob@example.com", nil, "Bob", "bob", time.Now()))
+	mock.ExpectExec("RELEASE SAVEPOINT oauth_user_insert").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("INSERT INTO user_providers").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	if _, err := UpsertOAuthUser(db, profile); err != nil {
+		t.Fatalf("UpsertOAuthUser: %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)


### PR DESCRIPTION
## Summary

Fixes #57 — OAuth/social logins (Google, GitHub, Telegram) no longer trigger the "verify your email" banner.

`repository.UpsertOAuthUser` never set `users.email_verified_at`, so OAuth accounts stayed `NULL` (unverified) and the web + mobile `VerifyEmailBanner` (`!is_guest && !email_verified`) showed for them. Signing in via a provider implies a verified email, so we now stamp it.

## Changes

- **New OAuth user** — INSERT sets `email_verified_at = NOW()`.
- **Existing/linked OAuth user** — UPDATE backfills `email_verified_at = COALESCE(email_verified_at, NOW())`, so accounts that linked OAuth after an unverified email/password signup are fixed on next login, while an already-set timestamp is preserved.

Backend-only. `GET /me` already derives `email_verified` from the column and both banners key off `me.email_verified`, so no handler, JWT, or frontend changes are needed. Email/password registration is unchanged (still sends a verification email). All providers including Telegram (no email) are marked verified, so Telegram users no longer see a meaningless prompt.

## Testing

- `make -C services/api test` — green (131 existing + 2 new).
- New `repository/user_test.go` cases assert the OAuth INSERT includes `email_verified_at` and the existing-user UPDATE uses `COALESCE(email_verified_at, NOW())`.
- `gofmt` clean.

> Note: a full DB-backed functional check couldn't run in this environment (local Postgres lacked the migrated schema / schema privileges), so verification is via the SQL-level unit tests. The change is purely additive to the OAuth upsert SQL.

## Notes

- No migration: fresh deploy; existing OAuth rows get stamped on next login via the COALESCE update.
