### PR TITLE
feat(email): configurable sender, go-mail library, redesigned templates (#59)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -128,6 +128,9 @@ Runtime config (`api`, `ws`) lives in env files on the server, referenced by `en
 | `SMTP_USER` | No | SMTP username |
 | `SMTP_PASS` | No | SMTP password |
 | `SMTP_FROM` | No | From address (default `no-reply@sevenspade.local`) |
+| `SMTP_FROM_NAME` | No | Display name on the From header (default `Seven Spade`) — e.g. `Seven Spade <no-reply@…>` |
+| `SMTP_REPLY_TO` | No | Optional Reply-To address (omitted when empty) |
+| `SMTP_ENCRYPTION` | No | Transport security: `auto` (default) \| `tls` \| `starttls` \| `none`. `auto` = implicit TLS on port 465, STARTTLS otherwise |
 | `GOOGLE_OAUTH_CLIENT_ID` | Optional | Google OAuth client ID |
 | `GOOGLE_OAUTH_CLIENT_SECRET` | Optional | Google OAuth client secret |
 | `GOOGLE_OAUTH_REDIRECT_URL` | Optional | `https://spade.example.com/auth/callback/google` |
@@ -514,7 +517,7 @@ EXPO_PUBLIC_WS_URL=wss://wsspade.fahrur.my.id
 
 > Replace `<REDACTED>` with real values before deploying. Store secrets outside the repo (use a secrets manager or environment-only injection).
 
-> **Optional vars not shown above:** the production API does not set `SMTP_*`, so password-reset / email-verification links are logged to the API container's stdout rather than emailed — set `SMTP_HOST` (and friends) to send real mail. `LEADERBOARD_MIN_GAMES` is left at its default of `5`.
+> **Optional vars not shown above:** the production API does not set `SMTP_*`, so password-reset / email-verification links are logged to the API container's stdout rather than emailed — set `SMTP_HOST` (and friends) to send real mail. When SMTP is configured, mail is sent with a `Seven Spade` From name (override with `SMTP_FROM_NAME`) and `SMTP_ENCRYPTION=auto` (implicit TLS on :465, STARTTLS otherwise). `LEADERBOARD_MIN_GAMES` is left at its default of `5`.
 
 ---
 

--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -44,3 +44,22 @@ GITHUB_OAUTH_REDIRECT_URL=http://localhost:5173/auth/callback/github
 TELEGRAM_OAUTH_CLIENT_ID=
 TELEGRAM_OAUTH_CLIENT_SECRET=
 TELEGRAM_OAUTH_REDIRECT_URL=http://localhost:5173/auth/callback/telegram
+
+# Transactional email (password reset / email verification).
+# When SMTP_HOST is empty the API logs the links to stdout (dev default) and
+# sends no mail — no SMTP server required for local development.
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASS=
+# From address used on outgoing mail.
+SMTP_FROM=no-reply@sevenspade.local
+# Display name on the From header, e.g. "Seven Spade <no-reply@...>".
+SMTP_FROM_NAME=Seven Spade
+# Optional Reply-To address (leave empty to omit).
+SMTP_REPLY_TO=
+# Transport security: auto | tls | starttls | none.
+# auto = implicit TLS on port 465, STARTTLS otherwise. Use "none" only for a
+# local test inbox like Mailpit (SMTP on :1025).
+SMTP_ENCRYPTION=auto
+

--- a/services/api/go.mod
+++ b/services/api/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/lestrrat-go/jwx/v2 v2.1.6
 	github.com/lib/pq v1.12.3
 	github.com/redis/go-redis/v9 v9.19.0
+	github.com/wneessen/go-mail v0.7.3
 	golang.org/x/crypto v0.51.0
 )
 

--- a/services/api/go.sum
+++ b/services/api/go.sum
@@ -106,6 +106,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY=
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
+github.com/wneessen/go-mail v0.7.3 h1:g3DravXC5SMlVdboFrQA8Jx95A8sOzoBeS5F+vzNRK0=
+github.com/wneessen/go-mail v0.7.3/go.mod h1:QGhBX0yNbc1J+Mkjcu7z2rpj4B4l+BmDY8gYznPC9sk=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=

--- a/services/api/internal/config/config.go
+++ b/services/api/internal/config/config.go
@@ -32,6 +32,9 @@ type Config struct {
 	SMTPUser            string
 	SMTPPass            string
 	SMTPFrom            string
+	SMTPFromName        string
+	SMTPReplyTo         string
+	SMTPEncryption      string
 	GoogleOAuth         OAuthCredentials
 	GitHubOAuth         OAuthCredentials
 	TelegramOAuth       OAuthCredentials
@@ -58,6 +61,9 @@ func Load() *Config {
 		SMTPUser:            os.Getenv("SMTP_USER"),
 		SMTPPass:            os.Getenv("SMTP_PASS"),
 		SMTPFrom:            getenv("SMTP_FROM", "no-reply@sevenspade.local"),
+		SMTPFromName:        getenv("SMTP_FROM_NAME", "Seven Spade"),
+		SMTPReplyTo:         os.Getenv("SMTP_REPLY_TO"),
+		SMTPEncryption:      getenv("SMTP_ENCRYPTION", "auto"),
 		GoogleOAuth: OAuthCredentials{
 			ClientID:     os.Getenv("GOOGLE_OAUTH_CLIENT_ID"),
 			ClientSecret: os.Getenv("GOOGLE_OAUTH_CLIENT_SECRET"),

--- a/services/api/internal/email/email.go
+++ b/services/api/internal/email/email.go
@@ -5,19 +5,29 @@
 //   - LogSender writes the link to the application log. It is the default in
 //     development so no SMTP server is required; the URL can be copied from the
 //     console to complete a flow.
-//   - SMTPSender delivers real mail via net/smtp, configured from SMTP_* env.
+//   - SMTPSender delivers real mail via github.com/wneessen/go-mail, configured
+//     from SMTP_* env, with a display-name From, HTML + plaintext alternatives,
+//     and configurable transport encryption.
 //
 // NewFromConfig picks SMTPSender when SMTP_HOST is set, otherwise LogSender.
+//
+// Email markup lives in templates/*.tmpl, embedded at build time. A single
+// data-driven layout renders both messages (HTML and plaintext); the per-email
+// copy (heading/intro/button/footnote) is supplied by the sender.
 package email
 
 import (
 	"bytes"
 	"context"
+	"embed"
 	"fmt"
-	"html/template"
+	htmltmpl "html/template"
 	"log"
-	"net/smtp"
 	"strings"
+	texttmpl "text/template"
+	"time"
+
+	"github.com/wneessen/go-mail"
 )
 
 // Sender delivers transactional emails. Implementations must be safe for
@@ -27,32 +37,74 @@ type Sender interface {
 	SendVerification(ctx context.Context, to, link string) error
 }
 
-var (
-	passwordResetTmpl = template.Must(template.New("reset").Parse(`<!doctype html>
-<html><body style="font-family:sans-serif;line-height:1.5">
-<h2>Reset your Seven Spade password</h2>
-<p>We received a request to reset your password. This link expires in 15 minutes and can be used once.</p>
-<p><a href="{{.Link}}">Reset your password</a></p>
-<p>If you didn't request this, you can safely ignore this email.</p>
-</body></html>`))
+//go:embed templates/*.tmpl
+var templateFS embed.FS
 
-	verificationTmpl = template.Must(template.New("verify").Parse(`<!doctype html>
-<html><body style="font-family:sans-serif;line-height:1.5">
-<h2>Verify your Seven Spade email</h2>
-<p>Confirm your email address to secure your account. This link expires in 24 hours.</p>
-<p><a href="{{.Link}}">Verify your email</a></p>
-<p>If you didn't create an account, you can safely ignore this email.</p>
-</body></html>`))
+var (
+	htmlLayout = htmltmpl.Must(htmltmpl.ParseFS(templateFS, "templates/layout.html.tmpl"))
+	textLayout = texttmpl.Must(texttmpl.ParseFS(templateFS, "templates/layout.txt.tmpl"))
 )
 
-type linkData struct{ Link string }
+// appName / appURL brand the templates. appURL is overridden from config so the
+// footer links to the deployed frontend.
+const appName = "Seven Spade"
 
-func renderHTML(tmpl *template.Template, link string) (string, error) {
-	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, linkData{Link: link}); err != nil {
-		return "", fmt.Errorf("email: render template: %w", err)
+// message holds the per-email copy fed into the shared layout.
+type message struct {
+	Subject     string
+	Preheader   string
+	Heading     string
+	Intro       string
+	ButtonLabel string
+	Footnote    string
+}
+
+// templateData is the full data set passed to both layouts.
+type templateData struct {
+	message
+	Link    string
+	AppName string
+	AppURL  string
+	Year    int
+}
+
+var (
+	passwordResetMsg = message{
+		Subject:     "Reset your Seven Spade password",
+		Preheader:   "Reset your password — this link expires in 15 minutes.",
+		Heading:     "Reset your password",
+		Intro:       "We received a request to reset your Seven Spade password. Tap the button below to choose a new one. This link expires in 15 minutes and can be used once.",
+		ButtonLabel: "Reset password",
+		Footnote:    "If you didn't request this, you can safely ignore this email — your password won't change.",
 	}
-	return buf.String(), nil
+	verificationMsg = message{
+		Subject:     "Verify your Seven Spade email",
+		Preheader:   "Confirm your email to secure your account.",
+		Heading:     "Verify your email",
+		Intro:       "Confirm your email address to secure your Seven Spade account and unlock account recovery. This link expires in 24 hours.",
+		ButtonLabel: "Verify email",
+		Footnote:    "If you didn't create a Seven Spade account, you can safely ignore this email.",
+	}
+)
+
+// render produces the HTML and plaintext bodies for a message + link.
+func render(msg message, link, appURL string) (html, text string, err error) {
+	data := templateData{
+		message: msg,
+		Link:    link,
+		AppName: appName,
+		AppURL:  appURL,
+		Year:    time.Now().Year(),
+	}
+	var hbuf bytes.Buffer
+	if err := htmlLayout.Execute(&hbuf, data); err != nil {
+		return "", "", fmt.Errorf("email: render html: %w", err)
+	}
+	var tbuf bytes.Buffer
+	if err := textLayout.Execute(&tbuf, data); err != nil {
+		return "", "", fmt.Errorf("email: render text: %w", err)
+	}
+	return hbuf.String(), tbuf.String(), nil
 }
 
 // LogSender writes the link to the log instead of sending mail. Used in dev.
@@ -68,58 +120,121 @@ func (LogSender) SendVerification(_ context.Context, to, link string) error {
 	return nil
 }
 
-// SMTPSender sends mail through an SMTP server.
+// Encryption selects the SMTP transport security policy.
+type Encryption string
+
+const (
+	// EncryptionAuto picks implicit TLS for port 465 and STARTTLS otherwise.
+	EncryptionAuto     Encryption = "auto"
+	EncryptionTLS      Encryption = "tls"      // implicit TLS (SMTPS, usually :465)
+	EncryptionSTARTTLS Encryption = "starttls" // explicit STARTTLS (usually :587)
+	EncryptionNone     Encryption = "none"     // plaintext (dev/local only)
+)
+
+// SMTPSender sends mail through an SMTP server via go-mail.
 type SMTPSender struct {
-	Host string
-	Port int
-	User string
-	Pass string
-	From string
+	Host       string
+	Port       int
+	User       string
+	Pass       string
+	From       string // envelope + header From address
+	FromName   string // optional display name on the From header
+	ReplyTo    string // optional Reply-To address
+	Encryption Encryption
+	AppURL     string // frontend base URL used in the email footer
 }
 
-func (s SMTPSender) send(to, subject, htmlBody string) error {
-	addr := fmt.Sprintf("%s:%d", s.Host, s.Port)
-	var auth smtp.Auth
-	if s.User != "" {
-		auth = smtp.PlainAuth("", s.User, s.Pass, s.Host)
+// tlsPolicy maps the configured Encryption (resolving "auto" by port) to a
+// go-mail TLS policy and whether SSL/implicit TLS should be on.
+func (s SMTPSender) tlsPolicy() (useSSL bool, policy mail.TLSPolicy) {
+	enc := s.Encryption
+	if enc == "" || enc == EncryptionAuto {
+		if s.Port == 465 {
+			enc = EncryptionTLS
+		} else {
+			enc = EncryptionSTARTTLS
+		}
 	}
-	var msg bytes.Buffer
-	fmt.Fprintf(&msg, "From: %s\r\n", s.From)
-	fmt.Fprintf(&msg, "To: %s\r\n", to)
-	fmt.Fprintf(&msg, "Subject: %s\r\n", subject)
-	msg.WriteString("MIME-Version: 1.0\r\n")
-	msg.WriteString("Content-Type: text/html; charset=UTF-8\r\n")
-	msg.WriteString("\r\n")
-	msg.WriteString(htmlBody)
-	if err := smtp.SendMail(addr, auth, s.From, []string{to}, msg.Bytes()); err != nil {
+	switch enc {
+	case EncryptionTLS:
+		return true, mail.TLSMandatory
+	case EncryptionNone:
+		return false, mail.NoTLS
+	case EncryptionSTARTTLS:
+		return false, mail.TLSMandatory
+	default:
+		return false, mail.TLSOpportunistic
+	}
+}
+
+func (s SMTPSender) send(ctx context.Context, to string, msg message, link string) error {
+	html, text, err := render(msg, link, s.AppURL)
+	if err != nil {
+		return err
+	}
+
+	m := mail.NewMsg()
+	if s.FromName != "" {
+		if err := m.FromFormat(s.FromName, s.From); err != nil {
+			return fmt.Errorf("email: set from: %w", err)
+		}
+	} else if err := m.From(s.From); err != nil {
+		return fmt.Errorf("email: set from: %w", err)
+	}
+	if err := m.To(to); err != nil {
+		return fmt.Errorf("email: set to: %w", err)
+	}
+	if s.ReplyTo != "" {
+		if err := m.ReplyTo(s.ReplyTo); err != nil {
+			return fmt.Errorf("email: set reply-to: %w", err)
+		}
+	}
+	m.Subject(msg.Subject)
+	m.SetBodyString(mail.TypeTextPlain, text)
+	m.AddAlternativeString(mail.TypeTextHTML, html)
+
+	useSSL, policy := s.tlsPolicy()
+	opts := []mail.Option{
+		mail.WithPort(s.Port),
+		mail.WithTLSPolicy(policy),
+		mail.WithTimeout(15 * time.Second),
+	}
+	if useSSL {
+		opts = append(opts, mail.WithSSLPort(false))
+	}
+	if s.User != "" {
+		opts = append(opts, mail.WithSMTPAuth(mail.SMTPAuthPlain), mail.WithUsername(s.User), mail.WithPassword(s.Pass))
+	}
+
+	client, err := mail.NewClient(s.Host, opts...)
+	if err != nil {
+		return fmt.Errorf("email: new client: %w", err)
+	}
+	if err := client.DialAndSendWithContext(ctx, m); err != nil {
 		return fmt.Errorf("email: send to %s: %w", to, err)
 	}
 	return nil
 }
 
-func (s SMTPSender) SendPasswordReset(_ context.Context, to, link string) error {
-	body, err := renderHTML(passwordResetTmpl, link)
-	if err != nil {
-		return err
-	}
-	return s.send(to, "Reset your Seven Spade password", body)
+func (s SMTPSender) SendPasswordReset(ctx context.Context, to, link string) error {
+	return s.send(ctx, to, passwordResetMsg, link)
 }
 
-func (s SMTPSender) SendVerification(_ context.Context, to, link string) error {
-	body, err := renderHTML(verificationTmpl, link)
-	if err != nil {
-		return err
-	}
-	return s.send(to, "Verify your Seven Spade email", body)
+func (s SMTPSender) SendVerification(ctx context.Context, to, link string) error {
+	return s.send(ctx, to, verificationMsg, link)
 }
 
 // Config is the subset of app config the email package needs.
 type Config struct {
-	SMTPHost string
-	SMTPPort int
-	SMTPUser string
-	SMTPPass string
-	SMTPFrom string
+	SMTPHost       string
+	SMTPPort       int
+	SMTPUser       string
+	SMTPPass       string
+	SMTPFrom       string
+	SMTPFromName   string
+	SMTPReplyTo    string
+	SMTPEncryption string
+	AppURL         string // frontend base URL (FRONTEND_URL) used in the footer
 }
 
 // NewFromConfig returns an SMTPSender when SMTP_HOST is configured, otherwise a
@@ -129,11 +244,19 @@ func NewFromConfig(cfg Config) Sender {
 		log.Printf("email: SMTP_HOST not set, using dev log sender (links printed to console)")
 		return LogSender{}
 	}
+	appURL := strings.TrimRight(cfg.AppURL, "/")
+	if appURL == "" {
+		appURL = "https://sevenspade.local"
+	}
 	return SMTPSender{
-		Host: cfg.SMTPHost,
-		Port: cfg.SMTPPort,
-		User: cfg.SMTPUser,
-		Pass: cfg.SMTPPass,
-		From: cfg.SMTPFrom,
+		Host:       cfg.SMTPHost,
+		Port:       cfg.SMTPPort,
+		User:       cfg.SMTPUser,
+		Pass:       cfg.SMTPPass,
+		From:       cfg.SMTPFrom,
+		FromName:   cfg.SMTPFromName,
+		ReplyTo:    cfg.SMTPReplyTo,
+		Encryption: Encryption(strings.ToLower(strings.TrimSpace(cfg.SMTPEncryption))),
+		AppURL:     appURL,
 	}
 }

--- a/services/api/internal/email/email_test.go
+++ b/services/api/internal/email/email_test.go
@@ -11,8 +11,40 @@ func TestNewFromConfigSelectsSender(t *testing.T) {
 		t.Fatal("empty SMTP config should yield a LogSender")
 	}
 	s := NewFromConfig(Config{SMTPHost: "smtp.example.com", SMTPPort: 587, SMTPFrom: "no-reply@x"})
-	if _, ok := s.(SMTPSender); !ok {
+	sender, ok := s.(SMTPSender)
+	if !ok {
 		t.Fatalf("configured SMTP host should yield an SMTPSender, got %T", s)
+	}
+	// AppURL falls back to a sane default when not provided.
+	if sender.AppURL == "" {
+		t.Fatal("SMTPSender.AppURL should default when AppURL is empty")
+	}
+}
+
+func TestNewFromConfigCarriesNewFields(t *testing.T) {
+	s := NewFromConfig(Config{
+		SMTPHost:       "smtp.example.com",
+		SMTPPort:       465,
+		SMTPFrom:       "no-reply@x",
+		SMTPFromName:   "Seven Spade",
+		SMTPReplyTo:    "support@x",
+		SMTPEncryption: "TLS",
+		AppURL:         "https://spade.example.com/",
+	}).(SMTPSender)
+
+	if s.FromName != "Seven Spade" {
+		t.Fatalf("FromName = %q, want Seven Spade", s.FromName)
+	}
+	if s.ReplyTo != "support@x" {
+		t.Fatalf("ReplyTo = %q, want support@x", s.ReplyTo)
+	}
+	// Encryption is normalized to lowercase.
+	if s.Encryption != EncryptionTLS {
+		t.Fatalf("Encryption = %q, want tls", s.Encryption)
+	}
+	// Trailing slash trimmed.
+	if s.AppURL != "https://spade.example.com" {
+		t.Fatalf("AppURL = %q, want trimmed", s.AppURL)
 	}
 }
 
@@ -26,20 +58,60 @@ func TestLogSenderDoesNotError(t *testing.T) {
 	}
 }
 
-func TestTemplatesRenderLink(t *testing.T) {
+// render produces HTML + plaintext bodies that both carry the link and the
+// per-email copy, wrapped in the shared brand layout.
+func TestRenderProducesHTMLAndText(t *testing.T) {
 	link := "https://app.test/reset-password?token=abc123"
-	body, err := renderHTML(passwordResetTmpl, link)
+	html, text, err := render(passwordResetMsg, link, "https://spade.example.com")
 	if err != nil {
 		t.Fatalf("render reset: %v", err)
 	}
-	if !strings.Contains(body, link) {
-		t.Fatalf("reset body missing link: %s", body)
+	for _, want := range []string{link, passwordResetMsg.ButtonLabel, passwordResetMsg.Heading, "SEVEN SPADE", "https://spade.example.com"} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("reset HTML missing %q", want)
+		}
 	}
-	vbody, err := renderHTML(verificationTmpl, "https://app.test/verify-email?token=xyz")
+	for _, want := range []string{link, passwordResetMsg.Heading, "Seven Spade"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("reset text missing %q", want)
+		}
+	}
+	// HTML body should not leak raw Go template directives.
+	if strings.Contains(html, "{{") {
+		t.Fatalf("reset HTML has unrendered template directive: %s", html)
+	}
+
+	vhtml, vtext, err := render(verificationMsg, "https://app.test/verify-email?token=xyz", "https://spade.example.com")
 	if err != nil {
 		t.Fatalf("render verify: %v", err)
 	}
-	if !strings.Contains(vbody, "verify-email?token=xyz") {
-		t.Fatalf("verify body missing link: %s", vbody)
+	if !strings.Contains(vhtml, "verify-email?token=xyz") || !strings.Contains(vtext, "verify-email?token=xyz") {
+		t.Fatalf("verify bodies missing link")
+	}
+}
+
+// tlsPolicy resolves "auto" by port and honours explicit overrides.
+func TestTLSPolicyResolution(t *testing.T) {
+	cases := []struct {
+		name    string
+		enc     Encryption
+		port    int
+		wantSSL bool
+	}{
+		{"auto 465 -> implicit TLS", EncryptionAuto, 465, true},
+		{"auto 587 -> starttls", EncryptionAuto, 587, false},
+		{"empty 465 -> implicit TLS", "", 465, true},
+		{"explicit tls", EncryptionTLS, 587, true},
+		{"explicit starttls", EncryptionSTARTTLS, 465, false},
+		{"explicit none", EncryptionNone, 25, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := SMTPSender{Port: tc.port, Encryption: tc.enc}
+			useSSL, _ := s.tlsPolicy()
+			if useSSL != tc.wantSSL {
+				t.Fatalf("useSSL = %v, want %v", useSSL, tc.wantSSL)
+			}
+		})
 	}
 }

--- a/services/api/internal/email/templates/layout.html.tmpl
+++ b/services/api/internal/email/templates/layout.html.tmpl
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="x-apple-disable-message-reformatting">
+  <meta name="color-scheme" content="dark light">
+  <meta name="supported-color-schemes" content="dark light">
+  <title>{{.Subject}}</title>
+</head>
+<body style="margin:0; padding:0; width:100%; background-color:#0d1a12; -webkit-text-size-adjust:100%; -ms-text-size-adjust:100%;">
+  <!-- Preheader (hidden) -->
+  <div style="display:none; max-height:0; overflow:hidden; opacity:0; mso-hide:all;">{{.Preheader}}&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;</div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#0d1a12" style="background-color:#0d1a12;">
+    <tr>
+      <td align="center" style="padding:32px 16px;">
+
+        <!-- Card -->
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:520px; width:100%; background-color:#15281b; border:1px solid #235c36; border-radius:14px; overflow:hidden;">
+
+          <!-- Brand header -->
+          <tr>
+            <td align="center" style="padding:28px 32px 8px 32px;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                  <td style="vertical-align:middle; padding-right:10px;">
+                    <span style="display:inline-block; font-size:28px; line-height:28px; color:#f5c842;">&spades;</span>
+                  </td>
+                  <td style="vertical-align:middle;">
+                    <span style="font-family:'DM Sans',Helvetica,Arial,sans-serif; font-size:18px; font-weight:700; letter-spacing:0.04em; color:#f4ead5;">SEVEN SPADE</span>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Gold divider -->
+          <tr>
+            <td style="padding:16px 32px 0 32px;">
+              <div style="height:2px; line-height:2px; font-size:2px; background-color:#c9922b; border-radius:2px;">&nbsp;</div>
+            </td>
+          </tr>
+
+          <!-- Body -->
+          <tr>
+            <td style="padding:24px 32px 8px 32px; font-family:'DM Sans',Helvetica,Arial,sans-serif;">
+              <h1 style="margin:0 0 12px 0; font-size:22px; line-height:1.3; font-weight:700; color:#f5c842;">{{.Heading}}</h1>
+              <p style="margin:0 0 20px 0; font-size:15px; line-height:1.6; color:#f4ead5;">{{.Intro}}</p>
+            </td>
+          </tr>
+
+          <!-- Bulletproof CTA button -->
+          <tr>
+            <td align="center" style="padding:4px 32px 8px 32px;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                  <td align="center" bgcolor="#c9922b" style="background-color:#c9922b; border-radius:8px;">
+                    <a href="{{.Link}}" target="_blank" style="display:inline-block; padding:13px 30px; font-family:'DM Sans',Helvetica,Arial,sans-serif; font-size:15px; font-weight:700; line-height:1; color:#1a1a1a; text-decoration:none; border-radius:8px;">{{.ButtonLabel}}</a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Fallback link -->
+          <tr>
+            <td style="padding:16px 32px 4px 32px; font-family:'DM Sans',Helvetica,Arial,sans-serif;">
+              <p style="margin:0 0 6px 0; font-size:12px; line-height:1.5; color:#9c9589;">Or paste this link into your browser:</p>
+              <p style="margin:0; font-size:12px; line-height:1.5; word-break:break-all;"><a href="{{.Link}}" target="_blank" style="color:#f5c842; text-decoration:underline;">{{.Link}}</a></p>
+            </td>
+          </tr>
+
+          <!-- Footnote -->
+          <tr>
+            <td style="padding:20px 32px 24px 32px; font-family:'DM Sans',Helvetica,Arial,sans-serif;">
+              <p style="margin:0; font-size:13px; line-height:1.6; color:#9c9589;">{{.Footnote}}</p>
+            </td>
+          </tr>
+
+        </table>
+
+        <!-- Footer -->
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:520px; width:100%;">
+          <tr>
+            <td align="center" style="padding:20px 32px; font-family:'DM Sans',Helvetica,Arial,sans-serif;">
+              <p style="margin:0 0 4px 0; font-size:12px; line-height:1.5; color:#5a5550;">You received this email because it was requested for your {{.AppName}} account. If it wasn't you, no action is needed.</p>
+              <p style="margin:0; font-size:12px; line-height:1.5; color:#5a5550;">&copy; {{.Year}} {{.AppName}} &middot; <a href="{{.AppURL}}" target="_blank" style="color:#9c9589; text-decoration:underline;">{{.AppURL}}</a></p>
+            </td>
+          </tr>
+        </table>
+
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/services/api/internal/email/templates/layout.txt.tmpl
+++ b/services/api/internal/email/templates/layout.txt.tmpl
@@ -1,0 +1,13 @@
+{{.Heading}}
+
+{{.Intro}}
+
+{{.ButtonLabel}}:
+{{.Link}}
+
+{{.Footnote}}
+
+--
+{{.AppName}}
+{{.AppURL}}
+You received this email because it was requested for your {{.AppName}} account. If it wasn't you, no action is needed.

--- a/services/api/internal/server/router.go
+++ b/services/api/internal/server/router.go
@@ -16,11 +16,15 @@ func NewRouter(cfg *config.Config, db *sql.DB, rdb *cache.RedisClient) *gin.Engi
 	r.Use(middleware.CORS(cfg.CORSAllowedOrigins))
 
 	emailSender := email.NewFromConfig(email.Config{
-		SMTPHost: cfg.SMTPHost,
-		SMTPPort: cfg.SMTPPort,
-		SMTPUser: cfg.SMTPUser,
-		SMTPPass: cfg.SMTPPass,
-		SMTPFrom: cfg.SMTPFrom,
+		SMTPHost:       cfg.SMTPHost,
+		SMTPPort:       cfg.SMTPPort,
+		SMTPUser:       cfg.SMTPUser,
+		SMTPPass:       cfg.SMTPPass,
+		SMTPFrom:       cfg.SMTPFrom,
+		SMTPFromName:   cfg.SMTPFromName,
+		SMTPReplyTo:    cfg.SMTPReplyTo,
+		SMTPEncryption: cfg.SMTPEncryption,
+		AppURL:         cfg.FrontendURL,
 	})
 
 	health := handler.HealthHandler{Service: "api", Checks: map[string]handler.DependencyCheck{


### PR DESCRIPTION
## Summary

Closes #59. Makes transactional email (password reset, verification) configurable, swaps the hand-rolled `net/smtp` sender for `github.com/wneessen/go-mail`, and redesigns the templates with an app-like, brand-matched style stored as embedded files.

## Configuration (all optional, back-compatible)

| Var | Default | Purpose |
|---|---|---|
| `SMTP_FROM_NAME` | `Seven Spade` | Display name on the From header (`Seven Spade <no-reply@…>`) |
| `SMTP_ENCRYPTION` | `auto` | `auto` \| `tls` \| `starttls` \| `none`; `auto` = implicit TLS on :465, STARTTLS otherwise |
| `SMTP_REPLY_TO` | _(empty)_ | Optional Reply-To |

Existing `SMTP_HOST/PORT/USER/PASS/FROM` unchanged.

## Mailer

- go-mail `Client` with context-aware `DialAndSendWithContext` + 15s timeout (the old `net/smtp` path ignored `ctx`).
- Display-name From, optional Reply-To, automatic `Date`/`Message-ID`.
- `multipart/alternative` — HTML **and** plaintext for deliverability/accessibility.

## Templates & design

- Moved out of Go source into `internal/email/templates/*.tmpl`, compiled in via `//go:embed`. A single data-driven layout (`layout.html.tmpl` + `layout.txt.tmpl`) renders both emails; per-email copy lives in the sender.
- Dark, brand-matched design: deep-green card, gold spade wordmark + CTA button, cream text — table-based with inline CSS, a bulletproof button, hidden preheader, fallback link, and footer.

## Testing

- `make -C services/api test` — green (141 total; new email tests cover sender selection, the new config fields, HTML+text render, and the TLS-policy resolver). `gofmt` clean.
- **End-to-end against a local Mailpit inbox** (SMTP :1025): registered a user + requested a reset → both emails delivered with the `Seven Spade` From name, HTML + plaintext parts, and correct links. Mailpit's HTML-compatibility check scored ~92%. Screenshot verified the rendered design; test data + inbox cleaned up afterward.

## Notes

- Backend-only — no frontend/mobile changes; the `email.Sender` interface and the reset/verify link format are preserved (handler tests untouched and green).
- No change to when emails are sent, token/TTL logic, or the dev `LogSender` fallback (still used when `SMTP_HOST` is unset).
