### PR TITLE
feat(matchmaking): add quick play

### DIFF
--- a/mobile/app/(app)/lobby.tsx
+++ b/mobile/app/(app)/lobby.tsx
@@ -11,6 +11,7 @@ import { ApiError } from '../../src/api/client'
 import {
   getRooms,
   postJoinRoom,
+  postQuickPlay,
   postRoom,
   type BotDifficulty,
   type RoomDto,
@@ -77,6 +78,9 @@ export default function LobbyScreen() {
   const [practiceBotDifficulty, setPracticeBotDifficulty] = useState<BotDifficulty>('medium')
   const [isStartingPractice, setIsStartingPractice] = useState(false)
   const [practiceError, setPracticeError] = useState<string | null>(null)
+
+  const [isQuickPlaying, setIsQuickPlaying] = useState(false)
+  const [quickPlayError, setQuickPlayError] = useState<string | null>(null)
 
   const [refreshNonce, setRefreshNonce] = useState(0)
 
@@ -179,6 +183,20 @@ export default function LobbyScreen() {
     }
   }
 
+  const handleQuickPlay = async () => {
+    setQuickPlayError(null)
+    setJoinError(null)
+    setIsQuickPlaying(true)
+    try {
+      const joined = await postQuickPlay(token)
+      router.push(`/(app)/room/${joined.id}`)
+    } catch (err) {
+      setQuickPlayError(getErrorMessage(err, 'Failed to find a game'))
+    } finally {
+      setIsQuickPlaying(false)
+    }
+  }
+
   const handleStartPractice = async () => {
     setPracticeError(null)
     setIsStartingPractice(true)
@@ -208,6 +226,9 @@ export default function LobbyScreen() {
         action={
           <View className="flex-row flex-wrap items-center gap-2">
             <Badge tone="waiting">{`${openRoomCount} waiting`}</Badge>
+            <Button onPress={handleQuickPlay} disabled={isQuickPlaying}>
+              {isQuickPlaying ? 'Finding...' : 'Quick Play'}
+            </Button>
             <Button onPress={() => { setPracticeError(null); setShowPractice(true) }}>Practice</Button>
             <Button variant="secondary" onPress={() => { setCreateError(null); setShowCreate(true) }}>Create</Button>
             <Button variant="secondary" onPress={() => { setJoinError(null); setShowJoin(true) }}>Join code</Button>
@@ -217,6 +238,7 @@ export default function LobbyScreen() {
         <View className="gap-3">
           <Text className="text-sm font-medium text-spade-gray-2">Public rooms</Text>
           {listError ? <Text className="text-xs text-spade-red">{listError}</Text> : null}
+          {quickPlayError ? <Text className="text-xs text-spade-red">{quickPlayError}</Text> : null}
           {!isLoadingRooms && rooms.length === 0 && !listError ? (
             <View className="rounded-spade-lg border border-dashed border-spade-cream/15 bg-spade-bg/40 p-8">
               <Text className="text-center text-sm text-spade-gray-2">No public rooms waiting.</Text>

--- a/mobile/src/api/lobby.ts
+++ b/mobile/src/api/lobby.ts
@@ -51,3 +51,10 @@ export function postJoinRoom(token: string | null, inviteCode: string): Promise<
     token,
   })
 }
+
+export function postQuickPlay(token: string | null): Promise<JoinRoomResponse> {
+  return apiRequest<JoinRoomResponse>('/rooms/quick-play', {
+    method: 'POST',
+    token,
+  })
+}

--- a/services/api/internal/cache/redis.go
+++ b/services/api/internal/cache/redis.go
@@ -90,7 +90,7 @@ func oauthStateKey(state string) string { return "oauth:state:" + state }
 // single-use: consumption atomically reads and deletes the key.
 
 func passwordResetKey(tokenHash string) string { return "password_reset:" + tokenHash }
-func emailVerifyKey(tokenHash string) string    { return "email_verify:" + tokenHash }
+func emailVerifyKey(tokenHash string) string   { return "email_verify:" + tokenHash }
 
 // StorePasswordResetToken stores tokenHash -> userID with the given TTL.
 func (r *RedisClient) StorePasswordResetToken(ctx context.Context, tokenHash, userID string, ttl time.Duration) error {
@@ -164,6 +164,17 @@ func (r *RedisClient) AllowEmailRate(ctx context.Context, scope, email string, l
 	return count <= int64(limit), nil
 }
 
+// AllowOnce enforces a one-action-per-window cooldown for a subject. It returns
+// true when the action is allowed and false when a previous action is still in
+// its cooldown window. On Redis errors it fails open, matching AllowEmailRate.
+func (r *RedisClient) AllowOnce(ctx context.Context, scope, subject string, window time.Duration) (bool, error) {
+	key := rateLimitKey(scope, subject)
+	ok, err := r.rdb.SetNX(ctx, key, "1", window).Result()
+	if err != nil {
+		return true, fmt.Errorf("cache: set cooldown: %w", err)
+	}
+	return ok, nil
+}
 
 // presenceKey is the key the WS service writes (with a TTL) while a user is
 // connected. The value is the user's current room_id (or "" when not in a

--- a/services/api/internal/cache/redis_test.go
+++ b/services/api/internal/cache/redis_test.go
@@ -143,3 +143,33 @@ func TestAllowEmailRateWindowResets(t *testing.T) {
 		t.Fatal("should be allowed again after the window resets")
 	}
 }
+
+func TestAllowOnceEnforcesCooldown(t *testing.T) {
+	client, mr := newTestRedis(t)
+	ctx := context.Background()
+
+	ok, err := client.AllowOnce(ctx, "quick_play", "user-1", 3*time.Second)
+	if err != nil {
+		t.Fatalf("first AllowOnce: %v", err)
+	}
+	if !ok {
+		t.Fatal("first attempt should be allowed")
+	}
+
+	ok, err = client.AllowOnce(ctx, "quick_play", "user-1", 3*time.Second)
+	if err != nil {
+		t.Fatalf("second AllowOnce: %v", err)
+	}
+	if ok {
+		t.Fatal("second attempt inside cooldown should be denied")
+	}
+
+	if ok, _ := client.AllowOnce(ctx, "quick_play", "user-2", 3*time.Second); !ok {
+		t.Fatal("different subject should have its own cooldown")
+	}
+
+	mr.FastForward(4 * time.Second)
+	if ok, _ := client.AllowOnce(ctx, "quick_play", "user-1", 3*time.Second); !ok {
+		t.Fatal("same subject should be allowed after cooldown")
+	}
+}

--- a/services/api/internal/handler/room.go
+++ b/services/api/internal/handler/room.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"log"
@@ -8,13 +9,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/faytranevozter/7spade/services/api/internal/cache"
 	"github.com/faytranevozter/7spade/services/api/internal/middleware"
 	"github.com/faytranevozter/7spade/services/api/internal/repository"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 )
 
-type RoomHandler struct{ DB *sql.DB }
+type RoomHandler struct {
+	DB    *sql.DB
+	Redis *cache.RedisClient
+}
 
 type createRoomRequest struct {
 	Visibility       string `json:"visibility"`
@@ -43,6 +48,8 @@ type joinRoomResponse struct {
 
 var validTurnTimers = map[int]bool{30: true, 60: true, 90: true, 120: true}
 var validBotDifficulties = map[string]bool{"easy": true, "medium": true, "hard": true}
+
+const quickPlayCooldown = 3 * time.Second
 
 func (h RoomHandler) Create(c *gin.Context) {
 	claims, ok := middleware.ClaimsFromContext(c)
@@ -164,6 +171,43 @@ func (h RoomHandler) Join(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, joinRoomResponse{ID: updated.ID.String(), InviteCode: updated.InviteCode, Status: updated.Status, PlayerCount: updated.PlayerCount})
+}
+
+func (h RoomHandler) QuickPlay(c *gin.Context) {
+	claims, ok := middleware.ClaimsFromContext(c)
+	if !ok {
+		JSONError(c, http.StatusUnauthorized, "Authentication required")
+		return
+	}
+	userID, err := uuid.Parse(claims.Sub)
+	if err != nil {
+		JSONError(c, http.StatusUnauthorized, "Invalid user identity")
+		return
+	}
+
+	if h.Redis != nil {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 2*time.Second)
+		defer cancel()
+		allowed, err := h.Redis.AllowOnce(ctx, "quick_play", userID.String(), quickPlayCooldown)
+		if err != nil {
+			log.Printf("rooms: quick-play rate limit check: %v", err)
+		} else if !allowed {
+			JSONError(c, http.StatusTooManyRequests, "Slow down before finding another game")
+			return
+		}
+	}
+
+	room, created, err := repository.QuickPlayRoom(h.DB, userID, claims.DisplayName)
+	if err != nil {
+		log.Printf("rooms: quick play: %v", err)
+		JSONError(c, http.StatusInternalServerError, "Failed to find a game")
+		return
+	}
+	status := http.StatusOK
+	if created {
+		status = http.StatusCreated
+	}
+	c.JSON(status, joinRoomResponse{ID: room.ID.String(), InviteCode: room.InviteCode, Status: room.Status, PlayerCount: room.PlayerCount})
 }
 
 func (h RoomHandler) Get(c *gin.Context) {

--- a/services/api/internal/repository/room.go
+++ b/services/api/internal/repository/room.go
@@ -102,6 +102,11 @@ func GetLiveGames(db *sql.DB) ([]LiveGame, error) {
 
 const inviteCodeChars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
 
+const (
+	QuickPlayTurnTimerSeconds = 60
+	QuickPlayBotDifficulty    = "medium"
+)
+
 var (
 	ErrRoomNotAcceptingPlayers = errors.New("room is not accepting players")
 	ErrRoomFull                = errors.New("room is full")
@@ -136,6 +141,78 @@ func CreateRoom(db *sql.DB, visibility string, turnTimerSeconds int, botDifficul
 		return nil, fmt.Errorf("create room: %w", err)
 	}
 	return room, nil
+}
+
+// QuickPlayRoom places a player into the oldest compatible public waiting room,
+// or creates a default public room when none is available. The selection and join
+// happen in one transaction so concurrent quick-play calls cannot overfill a
+// room. It returns created=true when it had to create a fallback room.
+func QuickPlayRoom(db *sql.DB, userID uuid.UUID, displayName string) (room RoomWithPlayerCount, created bool, retErr error) {
+	tx, err := db.Begin()
+	if err != nil {
+		return room, false, fmt.Errorf("begin transaction: %w", err)
+	}
+	defer func() {
+		if retErr != nil {
+			retErr = errors.Join(retErr, tx.Rollback())
+		}
+	}()
+
+	err = tx.QueryRow(`
+		WITH candidate AS (
+			SELECT r.id
+			FROM rooms r
+			WHERE r.visibility = 'public'
+			  AND r.status = 'waiting'
+			  AND r.practice_mode = false
+			  AND r.turn_timer_seconds = $1
+			  AND r.bot_difficulty = $2
+			  AND (SELECT COUNT(*) FROM room_players rp WHERE rp.room_id = r.id) < 4
+			  AND NOT EXISTS (
+			      SELECT 1 FROM room_players existing
+			      WHERE existing.room_id = r.id AND existing.user_id = $3
+			  )
+			ORDER BY r.created_at ASC
+			LIMIT 1
+			FOR UPDATE SKIP LOCKED
+		)
+		SELECT r.id, r.invite_code, r.visibility, r.turn_timer_seconds, r.bot_difficulty, r.practice_mode, r.status, r.created_by, r.created_at,
+		       (SELECT COUNT(*) FROM room_players rp WHERE rp.room_id = r.id) AS player_count
+		FROM rooms r
+		JOIN candidate ON candidate.id = r.id
+	`, QuickPlayTurnTimerSeconds, QuickPlayBotDifficulty, userID).Scan(
+		&room.ID, &room.InviteCode, &room.Visibility, &room.TurnTimerSeconds, &room.BotDifficulty, &room.PracticeMode, &room.Status, &room.CreatedBy, &room.CreatedAt, &room.PlayerCount,
+	)
+	if err != nil && err != sql.ErrNoRows {
+		return room, false, fmt.Errorf("find quick-play room: %w", err)
+	}
+
+	if err == sql.ErrNoRows {
+		inviteCode, err := GenerateInviteCode()
+		if err != nil {
+			return room, false, err
+		}
+		room = RoomWithPlayerCount{Room: Room{ID: uuid.New(), InviteCode: inviteCode, Visibility: "public", TurnTimerSeconds: QuickPlayTurnTimerSeconds, BotDifficulty: QuickPlayBotDifficulty, PracticeMode: false, Status: "waiting", CreatedBy: userID, CreatedAt: time.Now()}}
+		if err := tx.QueryRow(`
+			INSERT INTO rooms (id, invite_code, visibility, turn_timer_seconds, bot_difficulty, practice_mode, status, created_by, created_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+			RETURNING id, invite_code, visibility, turn_timer_seconds, bot_difficulty, practice_mode, status, created_by, created_at
+		`, room.ID, room.InviteCode, room.Visibility, room.TurnTimerSeconds, room.BotDifficulty, room.PracticeMode, room.Status, room.CreatedBy, room.CreatedAt).
+			Scan(&room.ID, &room.InviteCode, &room.Visibility, &room.TurnTimerSeconds, &room.BotDifficulty, &room.PracticeMode, &room.Status, &room.CreatedBy, &room.CreatedAt); err != nil {
+			return room, false, fmt.Errorf("create quick-play room: %w", err)
+		}
+		created = true
+	}
+
+	if _, err := tx.Exec(`INSERT INTO room_players (id, room_id, user_id, display_name, joined_at) VALUES ($1, $2, $3, $4, $5)`, uuid.New(), room.ID, userID, displayName, time.Now()); err != nil {
+		return room, created, fmt.Errorf("join quick-play room: %w", err)
+	}
+	room.PlayerCount++
+
+	if err := tx.Commit(); err != nil {
+		return room, created, fmt.Errorf("commit: %w", err)
+	}
+	return room, created, nil
 }
 
 func GetPublicWaitingRooms(db *sql.DB) ([]RoomWithPlayerCount, error) {

--- a/services/api/internal/repository/room_test.go
+++ b/services/api/internal/repository/room_test.go
@@ -53,6 +53,103 @@ func TestGetLiveGames(t *testing.T) {
 	}
 }
 
+func TestQuickPlayRoomJoinsOldestCompatibleRoom(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	roomID := uuid.New()
+	userID := uuid.New()
+	createdBy := uuid.New()
+	createdAt := time.Date(2026, 6, 8, 9, 0, 0, 0, time.UTC)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT r.id, r.invite_code, r.visibility")).
+		WithArgs(QuickPlayTurnTimerSeconds, QuickPlayBotDifficulty, userID).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "invite_code", "visibility", "turn_timer_seconds", "bot_difficulty", "practice_mode", "status", "created_by", "created_at", "player_count"}).
+			AddRow(roomID, "OLD123", "public", 60, "medium", false, "waiting", createdBy, createdAt, 2))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO room_players")).
+		WithArgs(sqlmock.AnyArg(), roomID, userID, "Alice", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	room, created, err := QuickPlayRoom(db, userID, "Alice")
+	if err != nil {
+		t.Fatalf("QuickPlayRoom: %v", err)
+	}
+	if created {
+		t.Fatal("expected to join existing room, got created=true")
+	}
+	if room.ID != roomID || room.InviteCode != "OLD123" || room.PlayerCount != 3 {
+		t.Fatalf("room = %+v", room)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestQuickPlayRoomCreatesDefaultRoomWhenNoneMatch(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	userID := uuid.New()
+	createdAt := time.Date(2026, 6, 8, 9, 0, 0, 0, time.UTC)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT r.id, r.invite_code, r.visibility")).
+		WithArgs(QuickPlayTurnTimerSeconds, QuickPlayBotDifficulty, userID).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "invite_code", "visibility", "turn_timer_seconds", "bot_difficulty", "practice_mode", "status", "created_by", "created_at", "player_count"}))
+	mock.ExpectQuery(regexp.QuoteMeta("INSERT INTO rooms")).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), "public", QuickPlayTurnTimerSeconds, QuickPlayBotDifficulty, false, "waiting", userID, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "invite_code", "visibility", "turn_timer_seconds", "bot_difficulty", "practice_mode", "status", "created_by", "created_at"}).
+			AddRow(uuid.New(), "NEW123", "public", 60, "medium", false, "waiting", userID, createdAt))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO room_players")).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), userID, "Alice", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	room, created, err := QuickPlayRoom(db, userID, "Alice")
+	if err != nil {
+		t.Fatalf("QuickPlayRoom: %v", err)
+	}
+	if !created {
+		t.Fatal("expected created=true")
+	}
+	if room.InviteCode != "NEW123" || room.Visibility != "public" || room.TurnTimerSeconds != 60 || room.BotDifficulty != "medium" || room.PracticeMode || room.PlayerCount != 1 {
+		t.Fatalf("room = %+v", room)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestQuickPlayRoomPropagatesSelectionError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	userID := uuid.New()
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT r.id, r.invite_code, r.visibility")).
+		WithArgs(QuickPlayTurnTimerSeconds, QuickPlayBotDifficulty, userID).
+		WillReturnError(sqlmock.ErrCancelled)
+	mock.ExpectRollback()
+
+	if _, _, err := QuickPlayRoom(db, userID, "Alice"); err == nil {
+		t.Fatal("expected query error to propagate")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 // GetLiveGames returns a non-nil empty slice when there are no live games.
 func TestGetLiveGamesEmpty(t *testing.T) {
 	db, mock, err := sqlmock.New()

--- a/services/api/internal/server/router.go
+++ b/services/api/internal/server/router.go
@@ -38,7 +38,7 @@ func NewRouter(cfg *config.Config, db *sql.DB, rdb *cache.RedisClient) *gin.Engi
 		Email:       emailSender,
 		FrontendURL: cfg.FrontendURL,
 	}
-	roomHandler := handler.RoomHandler{DB: db}
+	roomHandler := handler.RoomHandler{DB: db, Redis: rdb}
 	historyHandler := handler.HistoryHandler{DB: db}
 	statsHandler := handler.StatsHandler{DB: db, MinGames: cfg.LeaderboardMinGames}
 	oauthHandler := handler.NewOAuthHandler(db, rdb, cfg)
@@ -74,6 +74,7 @@ func NewRouter(cfg *config.Config, db *sql.DB, rdb *cache.RedisClient) *gin.Engi
 	authed := r.Group("")
 	authed.Use(middleware.RequireAuth(cfg.JWTSecret))
 	authed.POST("/rooms", roomHandler.Create)
+	authed.POST("/rooms/quick-play", roomHandler.QuickPlay)
 	authed.POST("/rooms/:code/join", roomHandler.Join)
 	authed.GET("/history", historyHandler.List)
 	authed.GET("/stats", statsHandler.Me)

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -9,7 +9,7 @@ import { getLeaderboard, getMyStats, getSeasons, getUserStats } from './api/stat
 import { getUserAchievements } from './api/achievements'
 import { getLiveGames } from './api/liveGames'
 import { getFriends } from './api/friends'
-import { getRoom, getRooms, postJoinRoom, postRoom } from './api/lobby'
+import { getRoom, getRooms, postJoinRoom, postQuickPlay, postRoom } from './api/lobby'
 
 vi.mock('./api/auth', () => ({
   AuthApiError: class AuthApiError extends Error {
@@ -37,6 +37,7 @@ vi.mock('./api/lobby', () => ({
   getRoom: vi.fn(),
   postRoom: vi.fn(),
   postJoinRoom: vi.fn(),
+  postQuickPlay: vi.fn(),
 }))
 
 vi.mock('./api/history', () => ({
@@ -103,6 +104,12 @@ beforeEach(() => {
     invite_code: 'XKQP7A',
     status: 'waiting',
     player_count: 4,
+  })
+  vi.mocked(postQuickPlay).mockResolvedValue({
+    id: 'quick-room',
+    invite_code: 'QUICK1',
+    status: 'waiting',
+    player_count: 1,
   })
   vi.mocked(getRoom).mockResolvedValue({
     id: 'room-1',
@@ -356,6 +363,38 @@ test('temporary buttons navigate through the hardcoded flow', async () => {
   fireEvent.click(screen.getAllByRole('button', { name: /^Join$/i })[0])
   await waitFor(() => {
     expect(screen.getByRole('heading', { name: /Waiting room/i })).toBeInTheDocument()
+  })
+})
+
+test('quick play finds a room and navigates to the waiting room', async () => {
+  renderRoute('/lobby')
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: /Quick Play/i })).toBeInTheDocument()
+  })
+
+  fireEvent.click(screen.getByRole('button', { name: /Quick Play/i }))
+
+  await waitFor(() => {
+    expect(postQuickPlay).toHaveBeenCalledWith('test-token')
+  })
+  await waitFor(() => {
+    expect(screen.getByRole('heading', { name: /Waiting room/i })).toBeInTheDocument()
+  })
+})
+
+test('quick play shows an error when matchmaking fails', async () => {
+  vi.mocked(postQuickPlay).mockRejectedValueOnce(new Error('Too many attempts'))
+  renderRoute('/lobby')
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: /Quick Play/i })).toBeInTheDocument()
+  })
+
+  fireEvent.click(screen.getByRole('button', { name: /Quick Play/i }))
+
+  await waitFor(() => {
+    expect(screen.getByRole('alert')).toHaveTextContent('Too many attempts')
   })
 })
 

--- a/web/src/api/lobby.ts
+++ b/web/src/api/lobby.ts
@@ -51,3 +51,10 @@ export function postJoinRoom(token: string | null, inviteCode: string): Promise<
     token,
   })
 }
+
+export function postQuickPlay(token: string | null): Promise<JoinRoomResponse> {
+  return apiRequest<JoinRoomResponse>('/rooms/quick-play', {
+    method: 'POST',
+    token,
+  })
+}

--- a/web/src/pages/LobbyPage.tsx
+++ b/web/src/pages/LobbyPage.tsx
@@ -9,6 +9,7 @@ import { ApiError } from '../api/client'
 import {
   getRooms,
   postJoinRoom,
+  postQuickPlay,
   postRoom,
   type BotDifficulty,
   type RoomDto,
@@ -76,6 +77,9 @@ export function LobbyPage() {
   const [practiceBotDifficulty, setPracticeBotDifficulty] = useState<BotDifficulty>('medium')
   const [isStartingPractice, setIsStartingPractice] = useState(false)
   const [practiceError, setPracticeError] = useState<string | null>(null)
+
+  const [isQuickPlaying, setIsQuickPlaying] = useState(false)
+  const [quickPlayError, setQuickPlayError] = useState<string | null>(null)
 
   const [refreshNonce, setRefreshNonce] = useState(0)
   const [searchParams, setSearchParams] = useSearchParams()
@@ -252,6 +256,20 @@ export function LobbyPage() {
     }
   }
 
+  const handleQuickPlay = async () => {
+    setQuickPlayError(null)
+    setJoinError(null)
+    setIsQuickPlaying(true)
+    try {
+      const joined = await postQuickPlay(token)
+      navigate(`/room/${joined.id}`)
+    } catch (err) {
+      setQuickPlayError(getErrorMessage(err, 'Failed to find a game'))
+    } finally {
+      setIsQuickPlaying(false)
+    }
+  }
+
   const openCreate = () => {
     setCreateError(null)
     setShowCreate(true)
@@ -295,6 +313,9 @@ export function LobbyPage() {
       action={
         <div className="flex flex-wrap items-center gap-2">
           <Badge tone="waiting">{`${openRoomCount} waiting`}</Badge>
+          <Button onClick={() => void handleQuickPlay()} disabled={isQuickPlaying}>
+            {isQuickPlaying ? 'Finding game…' : 'Quick Play'}
+          </Button>
           <Button onClick={openPractice}>Practice</Button>
           <Button variant="secondary" onClick={openCreate}>Create room</Button>
           <Button variant="secondary" onClick={openJoin}>Join by code</Button>
@@ -320,6 +341,11 @@ export function LobbyPage() {
         {joinError && !showJoin ? (
           <p role="alert" className="text-xs text-spade-red">
             {joinError}
+          </p>
+        ) : null}
+        {quickPlayError ? (
+          <p role="alert" className="text-xs text-spade-red">
+            {quickPlayError}
           </p>
         ) : null}
         {!isLoadingRooms && rooms.length === 0 && !listError ? (

--- a/web/src/pages/LobbyPage.tsx
+++ b/web/src/pages/LobbyPage.tsx
@@ -5,6 +5,7 @@ import { Button } from '../components/Button'
 import { Modal } from '../components/Modal'
 import { RoomCard } from '../components/RoomCard'
 import { SceneShell } from '../components/SceneShell'
+import { ToastStack } from '../components/ToastStack'
 import { ApiError } from '../api/client'
 import {
   getRooms,
@@ -19,10 +20,11 @@ import { useAuth } from '../hooks/useAuth'
 import { getLiveGames, type LiveGameDto } from '../api/liveGames'
 import { FriendsPanel } from '../components/FriendsPanel'
 import { decodeJwtClaims } from '../auth/claims'
-import type { Room } from '../types'
+import type { Room, Toast } from '../types'
 
 const TIMER_OPTIONS: ReadonlyArray<30 | 60 | 90 | 120> = [30, 60, 90, 120]
 const BOT_DIFFICULTY_OPTIONS: ReadonlyArray<BotDifficulty> = ['easy', 'medium', 'hard']
+const TOAST_TTL_MS = 4000
 
 function botDifficultyLabel(value: BotDifficulty): string {
   return value.charAt(0).toUpperCase() + value.slice(1)
@@ -79,10 +81,18 @@ export function LobbyPage() {
   const [practiceError, setPracticeError] = useState<string | null>(null)
 
   const [isQuickPlaying, setIsQuickPlaying] = useState(false)
-  const [quickPlayError, setQuickPlayError] = useState<string | null>(null)
+  const [quickPlayToasts, setQuickPlayToasts] = useState<Toast[]>([])
 
   const [refreshNonce, setRefreshNonce] = useState(0)
   const [searchParams, setSearchParams] = useSearchParams()
+
+  const pushQuickPlayToast = useCallback((toast: Omit<Toast, 'id'>) => {
+    const id = Date.now()
+    setQuickPlayToasts((current) => [{ ...toast, id }, ...current].slice(0, 2))
+    window.setTimeout(() => {
+      setQuickPlayToasts((current) => current.filter((t) => t.id !== id))
+    }, TOAST_TTL_MS)
+  }, [])
 
   useEffect(() => {
     if (!isAuthenticated) {
@@ -257,14 +267,14 @@ export function LobbyPage() {
   }
 
   const handleQuickPlay = async () => {
-    setQuickPlayError(null)
+    setQuickPlayToasts([])
     setJoinError(null)
     setIsQuickPlaying(true)
     try {
       const joined = await postQuickPlay(token)
       navigate(`/room/${joined.id}`)
     } catch (err) {
-      setQuickPlayError(getErrorMessage(err, 'Failed to find a game'))
+      pushQuickPlayToast({ tone: 'error', title: 'Quick Play failed', body: getErrorMessage(err, 'Failed to find a game') })
     } finally {
       setIsQuickPlaying(false)
     }
@@ -343,10 +353,10 @@ export function LobbyPage() {
             {joinError}
           </p>
         ) : null}
-        {quickPlayError ? (
-          <p role="alert" className="text-xs text-spade-red">
-            {quickPlayError}
-          </p>
+        {quickPlayToasts.length > 0 ? (
+          <div role="alert">
+            <ToastStack toasts={quickPlayToasts} />
+          </div>
         ) : null}
         {!isLoadingRooms && rooms.length === 0 && !listError ? (
           <div className="rounded-spade-lg border border-dashed border-spade-cream/15 bg-spade-bg/40 p-10 text-center">


### PR DESCRIPTION
## Summary
- add authenticated POST /rooms/quick-play for one-click matchmaking
- atomically join the oldest compatible public waiting room or create a default public room
- add a Redis-backed 3-second per-user quick-play cooldown
- add Quick Play CTAs to web and mobile lobbies with loading, error, and navigation behavior

## Verification
- cd services/api && make test
- cd web && npm test -- --run
- cd web && npm run build
- cd mobile && npx tsc --noEmit
- browser hot-reload flow: guest auth -> Quick Play -> /room/:id waiting room

## Notes
- cd web && npm run lint still reports an unrelated pre-existing react-hooks/set-state-in-effect issue in src/components/VerifyEmailBanner.tsx.