### PR TITLE
feat(matchmaking): add ranked quick play with ELO room constraints

### DIFF
--- a/docs/specs/seasons-and-elo.md
+++ b/docs/specs/seasons-and-elo.md
@@ -1,6 +1,6 @@
 # Spec: Seasons & Skill Rating (ELO)
 
-Status: Implemented (Phases A + B; Phase C deferred — see [#39](https://github.com/faytranevozter/7spade/issues/39))
+Status: Implemented
 Owner: —
 Related: [Player Stats & Leaderboard](./stats-and-leaderboard.md) · [HTTP API](../api.md) · [Architecture](../architecture.md)
 
@@ -23,8 +23,9 @@ are phased so seasons can ship before rating.
 > scope remains all-time; season is opt-in via the selector. The rating default is
 > **1200** (per issue #43) rather than 1000, with `K=24` pairwise expansion.
 > Lifetime rating lives on `user_stats.rating`; per-season rating on
-> `season_user_stats.rating`. Phase C (rating-based matchmaking) is deferred
-> pending Quick Play (#39).
+> `season_user_stats.rating`. Phase C is live as lobby-assist matchmaking:
+> casual Quick Play stays open/unconstrained, while separate Ranked Quick Play
+> uses the player's lifetime rating and a +/-200 room band.
 
 
 ### Goals
@@ -141,6 +142,21 @@ A "ranked" lobby option that groups players of similar rating. v1 scope is
 lobby-assist only (suggest/auto-join a room with nearby ratings); a true
 matchmaking queue is future work.
 
+### Implementation note (Phase C shipped)
+
+- Rooms may carry optional `min_elo` / `max_elo` constraints. Both values are
+  nullable together; `NULL`/`NULL` means a casual open room.
+- Manual joins enforce constraints, so invite-code and public-card joins cannot
+  bypass a ranked room's band. Guests can join unconstrained rooms only.
+- The lobby exposes two CTAs: **Quick Play** (casual, unconstrained rooms) and
+  **Ranked Quick Play** (registered users only, rating-constrained rooms).
+- Ranked Quick Play joins the oldest public waiting room whose ELO band contains
+  the player's lifetime `user_stats.rating` (default `1200` for first-time
+  players). If none match, it creates a public room with `rating - 200` to
+  `rating + 200`, clamping the lower bound at `0`.
+- Web and mobile lobbies split visible rooms into **Rating-matched rooms** and
+  **Open rooms** and render an `ELO min-max` badge for constrained rooms.
+
 ## 4. Edge Cases
 
 - **Guests / bots**: excluded from season stats and rating (no `user_id`),
@@ -173,7 +189,8 @@ matchmaking queue is future work.
    `?season=` leaderboard + `/seasons`, frontend selector.
 2. **Phase B**: migration `007` (rating column), rating update in `SaveGame`,
    rating leaderboard mode + profile rating.
-3. **Phase C (optional)**: rating-based matchmaking in the lobby.
+3. **Phase C**: rating-based matchmaking in the lobby via room ELO constraints
+   and Ranked Quick Play.
 4. All additive; the all-time leaderboard and existing endpoints are untouched.
 
 ## 7. Open Questions / Future Work

--- a/mobile/app/(app)/lobby.tsx
+++ b/mobile/app/(app)/lobby.tsx
@@ -18,6 +18,7 @@ import {
   type RoomVisibility,
 } from '../../src/api/lobby'
 import { getLiveGames, type LiveGameDto } from '../../src/api/liveGames'
+import { getMyStats } from '../../src/api/stats'
 import { useAuth } from '../../src/hooks/useAuth'
 import { decodeJwtClaims } from '../../src/auth/claims'
 import type { Room } from '../../src/types'
@@ -31,6 +32,7 @@ function botDifficultyLabel(value: BotDifficulty): string {
 
 function roomDtoToRoom(dto: RoomDto): Room {
   const fillStatus = dto.player_count >= 4 ? 'Full' : `${dto.player_count} / 4 players`
+  const eloRange = dto.min_elo !== null && dto.max_elo !== null ? `ELO ${dto.min_elo}-${dto.max_elo}` : undefined
   return {
     name: dto.visibility === 'private' ? 'Private room' : 'Public room',
     code: dto.invite_code,
@@ -38,6 +40,7 @@ function roomDtoToRoom(dto: RoomDto): Room {
     status: dto.status === 'waiting' ? fillStatus : `Status: ${dto.status}`,
     timer: `${dto.turn_timer_seconds}s`,
     botDifficulty: botDifficultyLabel(dto.bot_difficulty),
+    eloRange,
     open: dto.status === 'waiting' && dto.player_count < 4,
     filledSeats: Math.min(dto.player_count, 4),
     maxSeats: 4,
@@ -64,6 +67,9 @@ export default function LobbyScreen() {
   const [visibility, setVisibility] = useState<RoomVisibility>('public')
   const [timer, setTimer] = useState<30 | 60 | 90 | 120>(60)
   const [botDifficulty, setBotDifficulty] = useState<BotDifficulty>('medium')
+  const [limitByRating, setLimitByRating] = useState(false)
+  const [minElo, setMinElo] = useState(1000)
+  const [maxElo, setMaxElo] = useState(1400)
   const [isCreating, setIsCreating] = useState(false)
   const [createError, setCreateError] = useState<string | null>(null)
   const [showCreate, setShowCreate] = useState(false)
@@ -80,7 +86,9 @@ export default function LobbyScreen() {
   const [practiceError, setPracticeError] = useState<string | null>(null)
 
   const [isQuickPlaying, setIsQuickPlaying] = useState(false)
+  const [isRankedQuickPlaying, setIsRankedQuickPlaying] = useState(false)
   const [quickPlayError, setQuickPlayError] = useState<string | null>(null)
+  const [myRating, setMyRating] = useState<number | null>(null)
 
   const [refreshNonce, setRefreshNonce] = useState(0)
 
@@ -118,6 +126,21 @@ export default function LobbyScreen() {
 
   useEffect(() => loadRooms(false), [loadRooms, refreshNonce])
 
+  useEffect(() => {
+    if (isGuest) return
+    let cancelled = false
+    getMyStats(token)
+      .then((stats) => {
+        if (!cancelled) setMyRating(stats.rating)
+      })
+      .catch(() => {
+        if (!cancelled) setMyRating(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [isGuest, token])
+
   const loadLiveGames = useCallback(() => {
     let cancelled = false
     getLiveGames(token)
@@ -144,7 +167,12 @@ export default function LobbyScreen() {
     setCreateError(null)
     setIsCreating(true)
     try {
-      const created = await postRoom(token, { visibility, turn_timer_seconds: timer, bot_difficulty: botDifficulty })
+      const created = await postRoom(token, {
+        visibility,
+        turn_timer_seconds: timer,
+        bot_difficulty: botDifficulty,
+        ...(limitByRating && visibility === 'public' ? { min_elo: minElo, max_elo: maxElo } : {}),
+      })
       setShowCreate(false)
       router.push(`/(app)/room/${created.id}`)
     } catch (err) {
@@ -197,6 +225,24 @@ export default function LobbyScreen() {
     }
   }
 
+  const handleRankedQuickPlay = async () => {
+    setQuickPlayError(null)
+    setJoinError(null)
+    if (isGuest) {
+      setQuickPlayError('Sign in to use ranked matchmaking')
+      return
+    }
+    setIsRankedQuickPlaying(true)
+    try {
+      const joined = await postQuickPlay(token, { ranked: true })
+      router.push(`/(app)/room/${joined.id}`)
+    } catch (err) {
+      setQuickPlayError(getErrorMessage(err, 'Failed to find a ranked game'))
+    } finally {
+      setIsRankedQuickPlaying(false)
+    }
+  }
+
   const handleStartPractice = async () => {
     setPracticeError(null)
     setIsStartingPractice(true)
@@ -217,6 +263,10 @@ export default function LobbyScreen() {
   }
 
   const openRoomCount = rooms.filter((room) => room.status === 'waiting' && room.player_count < 4).length
+  const isConstrainedRoom = (room: RoomDto) => room.min_elo !== null && room.max_elo !== null
+  const matchesMyRating = (room: RoomDto) => myRating !== null && room.min_elo !== null && room.max_elo !== null && myRating >= room.min_elo && myRating <= room.max_elo
+  const ratingMatchedRooms = rooms.filter((room) => isConstrainedRoom(room) && matchesMyRating(room))
+  const openRooms = rooms.filter((room) => !isConstrainedRoom(room))
 
   return (
     <View className="flex-1 bg-spade-bg">
@@ -228,6 +278,9 @@ export default function LobbyScreen() {
             <Badge tone="waiting">{`${openRoomCount} waiting`}</Badge>
             <Button onPress={handleQuickPlay} disabled={isQuickPlaying}>
               {isQuickPlaying ? 'Finding...' : 'Quick Play'}
+            </Button>
+            <Button variant="secondary" onPress={handleRankedQuickPlay} disabled={isRankedQuickPlaying || isGuest}>
+              {isRankedQuickPlaying ? 'Finding ranked...' : 'Ranked Quick Play'}
             </Button>
             <Button onPress={() => { setPracticeError(null); setShowPractice(true) }}>Practice</Button>
             <Button variant="secondary" onPress={() => { setCreateError(null); setShowCreate(true) }}>Create</Button>
@@ -245,9 +298,22 @@ export default function LobbyScreen() {
               <Text className="mt-1 text-center text-xs text-spade-gray-3">Create one to get the table started.</Text>
             </View>
           ) : null}
-          {rooms.map((room) => (
-            <RoomCard key={room.id} room={roomDtoToRoom(room)} onJoin={() => void handleJoinPublic(room)} />
-          ))}
+          {ratingMatchedRooms.length > 0 ? (
+            <View className="gap-3">
+              <Text className="text-sm font-medium text-spade-gray-2">Rating-matched rooms</Text>
+              {ratingMatchedRooms.map((room) => (
+                <RoomCard key={room.id} room={roomDtoToRoom(room)} onJoin={() => void handleJoinPublic(room)} />
+              ))}
+            </View>
+          ) : null}
+          {openRooms.length > 0 ? (
+            <View className="gap-3">
+              <Text className="text-sm font-medium text-spade-gray-2">Open rooms</Text>
+              {openRooms.map((room) => (
+                <RoomCard key={room.id} room={roomDtoToRoom(room)} onJoin={() => void handleJoinPublic(room)} />
+              ))}
+            </View>
+          ) : null}
 
           {liveGames.length > 0 ? (
             <View className="mt-2 gap-2">
@@ -332,6 +398,41 @@ export default function LobbyScreen() {
                 ))}
               </View>
             </View>
+            {visibility === 'public' ? (
+              <View className="gap-3 rounded-spade-md border border-spade-cream/10 bg-spade-bg/40 p-3">
+                <Button variant={limitByRating ? 'primary' : 'secondary'} onPress={() => {
+                  if (!limitByRating && myRating !== null) {
+                    setMinElo(Math.max(0, myRating - 200))
+                    setMaxElo(myRating + 200)
+                  }
+                  setLimitByRating((v) => !v)
+                }}>
+                  {limitByRating ? 'Rating limit on' : 'Limit by rating'}
+                </Button>
+                {limitByRating ? (
+                  <View className="gap-3">
+                    <View className="gap-1.5">
+                      <Text className="text-xs font-medium uppercase text-spade-gray-2">Min rating</Text>
+                      <TextInput
+                        value={String(minElo)}
+                        onChangeText={(value) => setMinElo(Number(value) || 0)}
+                        keyboardType="number-pad"
+                        className="rounded-spade-md border border-spade-gray-4/60 bg-spade-bg px-3 py-2 text-sm text-spade-cream"
+                      />
+                    </View>
+                    <View className="gap-1.5">
+                      <Text className="text-xs font-medium uppercase text-spade-gray-2">Max rating</Text>
+                      <TextInput
+                        value={String(maxElo)}
+                        onChangeText={(value) => setMaxElo(Number(value) || 0)}
+                        keyboardType="number-pad"
+                        className="rounded-spade-md border border-spade-gray-4/60 bg-spade-bg px-3 py-2 text-sm text-spade-cream"
+                      />
+                    </View>
+                  </View>
+                ) : null}
+              </View>
+            ) : null}
             {createError ? <Text className="text-xs text-spade-red">{createError}</Text> : null}
             <View className="gap-2">
               <Button onPress={handleCreateRoom} disabled={isCreating}>

--- a/mobile/src/api/lobby.ts
+++ b/mobile/src/api/lobby.ts
@@ -11,6 +11,8 @@ export type RoomDto = {
   turn_timer_seconds: number
   bot_difficulty: BotDifficulty
   practice_mode: boolean
+  min_elo: number | null
+  max_elo: number | null
   status: RoomStatus
   player_count: number
 }
@@ -20,6 +22,12 @@ export type CreateRoomRequest = {
   turn_timer_seconds: number
   bot_difficulty: BotDifficulty
   practice_mode?: boolean
+  min_elo?: number
+  max_elo?: number
+}
+
+export type QuickPlayRequest = {
+  ranked?: boolean
 }
 
 export type JoinRoomResponse = {
@@ -52,9 +60,10 @@ export function postJoinRoom(token: string | null, inviteCode: string): Promise<
   })
 }
 
-export function postQuickPlay(token: string | null): Promise<JoinRoomResponse> {
+export function postQuickPlay(token: string | null, body?: QuickPlayRequest): Promise<JoinRoomResponse> {
   return apiRequest<JoinRoomResponse>('/rooms/quick-play', {
     method: 'POST',
     token,
+    body,
   })
 }

--- a/mobile/src/components/RoomCard.tsx
+++ b/mobile/src/components/RoomCard.tsx
@@ -31,6 +31,8 @@ export function RoomCard({ room, onJoin }: { room: Room; onJoin?: () => void }) 
         <Text className="font-mono text-[11px] text-spade-gray-3">{room.players} · {room.timer} · Bots: {room.botDifficulty}</Text>
       </View>
 
+      {room.eloRange ? <Text className="font-mono text-[11px] uppercase tracking-wider text-spade-gold-light">{room.eloRange}</Text> : null}
+
       <Button variant={room.open ? 'primary' : 'secondary'} disabled={!room.open} onPress={onJoin}>
         {room.open ? 'Join' : 'Full'}
       </Button>

--- a/mobile/src/types.ts
+++ b/mobile/src/types.ts
@@ -38,6 +38,7 @@ export type Room = {
   status: string
   timer: string
   botDifficulty: string
+  eloRange?: string
   open: boolean
   filledSeats: number
   maxSeats: number

--- a/services/api/internal/database/migrations/017_room_elo_constraints.sql
+++ b/services/api/internal/database/migrations/017_room_elo_constraints.sql
@@ -1,0 +1,17 @@
+ALTER TABLE rooms
+    ADD COLUMN IF NOT EXISTS min_elo INTEGER NULL,
+    ADD COLUMN IF NOT EXISTS max_elo INTEGER NULL;
+
+ALTER TABLE rooms
+    DROP CONSTRAINT IF EXISTS rooms_elo_range_check;
+
+ALTER TABLE rooms
+    ADD CONSTRAINT rooms_elo_range_check
+    CHECK (
+        (min_elo IS NULL AND max_elo IS NULL)
+        OR (min_elo IS NOT NULL AND max_elo IS NOT NULL AND min_elo >= 0 AND max_elo >= min_elo)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_rooms_public_waiting_elo
+    ON rooms(status, visibility, min_elo, max_elo)
+    WHERE practice_mode = false;

--- a/services/api/internal/handler/room.go
+++ b/services/api/internal/handler/room.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/faytranevozter/7spade/services/api/internal/auth"
 	"github.com/faytranevozter/7spade/services/api/internal/cache"
 	"github.com/faytranevozter/7spade/services/api/internal/middleware"
 	"github.com/faytranevozter/7spade/services/api/internal/repository"
@@ -26,6 +27,8 @@ type createRoomRequest struct {
 	TurnTimerSeconds int    `json:"turn_timer_seconds"`
 	BotDifficulty    string `json:"bot_difficulty"`
 	PracticeMode     bool   `json:"practice_mode"`
+	MinElo           *int   `json:"min_elo"`
+	MaxElo           *int   `json:"max_elo"`
 }
 
 type roomResponse struct {
@@ -35,6 +38,8 @@ type roomResponse struct {
 	TurnTimerSeconds int    `json:"turn_timer_seconds"`
 	BotDifficulty    string `json:"bot_difficulty"`
 	PracticeMode     bool   `json:"practice_mode"`
+	MinElo           *int   `json:"min_elo"`
+	MaxElo           *int   `json:"max_elo"`
 	Status           string `json:"status"`
 	PlayerCount      int    `json:"player_count"`
 }
@@ -44,6 +49,10 @@ type joinRoomResponse struct {
 	InviteCode  string `json:"invite_code"`
 	Status      string `json:"status"`
 	PlayerCount int    `json:"player_count"`
+}
+
+type quickPlayRequest struct {
+	Ranked bool `json:"ranked"`
 }
 
 var validTurnTimers = map[int]bool{30: true, 60: true, 90: true, 120: true}
@@ -84,18 +93,32 @@ func (h RoomHandler) Create(c *gin.Context) {
 		JSONError(c, http.StatusBadRequest, "Bot difficulty must be 'easy', 'medium', or 'hard'")
 		return
 	}
+	minElo, maxElo, ok := validateEloRange(c, req.MinElo, req.MaxElo)
+	if !ok {
+		return
+	}
+	if req.PracticeMode {
+		minElo = nil
+		maxElo = nil
+	}
 	userID, err := uuid.Parse(claims.Sub)
 	if err != nil {
 		JSONError(c, http.StatusUnauthorized, "Invalid user identity")
 		return
 	}
-	room, err := repository.CreateRoom(h.DB, visibility, req.TurnTimerSeconds, botDifficulty, req.PracticeMode, userID)
+	room, err := repository.CreateRoom(h.DB, visibility, req.TurnTimerSeconds, botDifficulty, req.PracticeMode, minElo, maxElo, userID)
 	if err != nil {
 		log.Printf("rooms: create room: %v", err)
 		JSONError(c, http.StatusInternalServerError, "Failed to create room")
 		return
 	}
-	if _, err := repository.AddPlayerToRoom(h.DB, room.ID, userID, claims.DisplayName); err != nil {
+	rating, err := h.ratingForJoin(claims)
+	if err != nil {
+		log.Printf("rooms: load creator rating: %v", err)
+		JSONError(c, http.StatusInternalServerError, "Failed to create room")
+		return
+	}
+	if _, err := repository.AddPlayerToRoom(h.DB, room.ID, repository.JoinRoomPlayer{UserID: userID, DisplayName: claims.DisplayName, Rating: rating}); err != nil {
 		log.Printf("rooms: join created room: %v", err)
 		JSONError(c, http.StatusInternalServerError, "Failed to join created room")
 		return
@@ -155,7 +178,13 @@ func (h RoomHandler) Join(c *gin.Context) {
 		JSONError(c, http.StatusUnauthorized, "Invalid user identity")
 		return
 	}
-	newCount, err := repository.AddPlayerToRoom(h.DB, room.ID, userID, claims.DisplayName)
+	rating, err := h.ratingForJoin(claims)
+	if err != nil {
+		log.Printf("rooms: load join rating: %v", err)
+		JSONError(c, http.StatusInternalServerError, "Failed to join room")
+		return
+	}
+	newCount, err := repository.AddPlayerToRoom(h.DB, room.ID, repository.JoinRoomPlayer{UserID: userID, DisplayName: claims.DisplayName, Rating: rating})
 	if err != nil {
 		status, msg := classifyJoinError(err)
 		JSONError(c, status, msg)
@@ -184,6 +213,17 @@ func (h RoomHandler) QuickPlay(c *gin.Context) {
 		JSONError(c, http.StatusUnauthorized, "Invalid user identity")
 		return
 	}
+	var req quickPlayRequest
+	if c.Request.Body != nil && c.Request.ContentLength != 0 {
+		if err := c.ShouldBindJSON(&req); err != nil {
+			JSONError(c, http.StatusBadRequest, "Invalid request body")
+			return
+		}
+	}
+	if req.Ranked && claims.IsGuest {
+		JSONError(c, http.StatusUnauthorized, "Logged-in user required")
+		return
+	}
 
 	if h.Redis != nil {
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 2*time.Second)
@@ -197,7 +237,17 @@ func (h RoomHandler) QuickPlay(c *gin.Context) {
 		}
 	}
 
-	room, created, err := repository.QuickPlayRoom(h.DB, userID, claims.DisplayName)
+	var rating *int
+	if req.Ranked {
+		value, err := repository.GetUserRating(h.DB, userID)
+		if err != nil {
+			log.Printf("rooms: quick-play rating: %v", err)
+			JSONError(c, http.StatusInternalServerError, "Failed to find a game")
+			return
+		}
+		rating = &value
+	}
+	room, created, err := repository.QuickPlayRoom(h.DB, repository.QuickPlayOptions{UserID: userID, DisplayName: claims.DisplayName, Rating: rating, Ranked: req.Ranked})
 	if err != nil {
 		log.Printf("rooms: quick play: %v", err)
 		JSONError(c, http.StatusInternalServerError, "Failed to find a game")
@@ -330,7 +380,7 @@ func (h RoomHandler) Reconcile(c *gin.Context) {
 }
 
 func newRoomResponse(room repository.RoomWithPlayerCount) roomResponse {
-	return roomResponse{ID: room.ID.String(), InviteCode: room.InviteCode, Visibility: room.Visibility, TurnTimerSeconds: room.TurnTimerSeconds, BotDifficulty: room.BotDifficulty, PracticeMode: room.PracticeMode, Status: room.Status, PlayerCount: room.PlayerCount}
+	return roomResponse{ID: room.ID.String(), InviteCode: room.InviteCode, Visibility: room.Visibility, TurnTimerSeconds: room.TurnTimerSeconds, BotDifficulty: room.BotDifficulty, PracticeMode: room.PracticeMode, MinElo: room.MinElo, MaxElo: room.MaxElo, Status: room.Status, PlayerCount: room.PlayerCount}
 }
 
 func classifyJoinError(err error) (int, string) {
@@ -341,10 +391,42 @@ func classifyJoinError(err error) (int, string) {
 		return http.StatusConflict, "Room is not accepting players"
 	case errors.Is(err, repository.ErrPlayerAlreadyInRoom):
 		return http.StatusConflict, "Already in room"
+	case errors.Is(err, repository.ErrRoomRatingRestricted):
+		return http.StatusForbidden, "Your rating is outside this room's range"
 	case errors.Is(err, sql.ErrNoRows):
 		return http.StatusNotFound, "Room not found"
 	default:
 		log.Printf("rooms: unexpected join error: %v", err)
 		return http.StatusInternalServerError, "Failed to join room"
 	}
+}
+
+func validateEloRange(c *gin.Context, minElo, maxElo *int) (*int, *int, bool) {
+	if minElo == nil && maxElo == nil {
+		return nil, nil, true
+	}
+	if minElo == nil || maxElo == nil {
+		JSONError(c, http.StatusBadRequest, "Both min_elo and max_elo are required")
+		return nil, nil, false
+	}
+	if *minElo < 0 || *maxElo < 0 || *minElo > *maxElo {
+		JSONError(c, http.StatusBadRequest, "ELO range must be non-negative and min_elo must be <= max_elo")
+		return nil, nil, false
+	}
+	return minElo, maxElo, true
+}
+
+func (h RoomHandler) ratingForJoin(claims *auth.Claims) (*int, error) {
+	if claims.IsGuest {
+		return nil, nil
+	}
+	userID, err := uuid.Parse(claims.Sub)
+	if err != nil {
+		return nil, err
+	}
+	rating, err := repository.GetUserRating(h.DB, userID)
+	if err != nil {
+		return nil, err
+	}
+	return &rating, nil
 }

--- a/services/api/internal/repository/room.go
+++ b/services/api/internal/repository/room.go
@@ -19,6 +19,8 @@ type Room struct {
 	TurnTimerSeconds int
 	BotDifficulty    string
 	PracticeMode     bool
+	MinElo           *int
+	MaxElo           *int
 	Status           string
 	CreatedBy        uuid.UUID
 	CreatedAt        time.Time
@@ -105,13 +107,28 @@ const inviteCodeChars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
 const (
 	QuickPlayTurnTimerSeconds = 60
 	QuickPlayBotDifficulty    = "medium"
+	RankedQuickPlayEloRange   = 200
 )
 
 var (
 	ErrRoomNotAcceptingPlayers = errors.New("room is not accepting players")
 	ErrRoomFull                = errors.New("room is full")
 	ErrPlayerAlreadyInRoom     = errors.New("already in room")
+	ErrRoomRatingRestricted    = errors.New("room rating restricted")
 )
+
+type JoinRoomPlayer struct {
+	UserID      uuid.UUID
+	DisplayName string
+	Rating      *int
+}
+
+type QuickPlayOptions struct {
+	UserID      uuid.UUID
+	DisplayName string
+	Rating      *int
+	Ranked      bool
+}
 
 func GenerateInviteCode() (string, error) {
 	code := make([]byte, 6)
@@ -125,18 +142,18 @@ func GenerateInviteCode() (string, error) {
 	return string(code), nil
 }
 
-func CreateRoom(db *sql.DB, visibility string, turnTimerSeconds int, botDifficulty string, practiceMode bool, createdBy uuid.UUID) (*Room, error) {
+func CreateRoom(db *sql.DB, visibility string, turnTimerSeconds int, botDifficulty string, practiceMode bool, minElo, maxElo *int, createdBy uuid.UUID) (*Room, error) {
 	inviteCode, err := GenerateInviteCode()
 	if err != nil {
 		return nil, err
 	}
-	room := &Room{ID: uuid.New(), InviteCode: inviteCode, Visibility: visibility, TurnTimerSeconds: turnTimerSeconds, BotDifficulty: botDifficulty, PracticeMode: practiceMode, Status: "waiting", CreatedBy: createdBy, CreatedAt: time.Now()}
+	room := &Room{ID: uuid.New(), InviteCode: inviteCode, Visibility: visibility, TurnTimerSeconds: turnTimerSeconds, BotDifficulty: botDifficulty, PracticeMode: practiceMode, MinElo: minElo, MaxElo: maxElo, Status: "waiting", CreatedBy: createdBy, CreatedAt: time.Now()}
 	err = db.QueryRow(`
-		INSERT INTO rooms (id, invite_code, visibility, turn_timer_seconds, bot_difficulty, practice_mode, status, created_by, created_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-		RETURNING id, invite_code, visibility, turn_timer_seconds, bot_difficulty, practice_mode, status, created_by, created_at
-	`, room.ID, room.InviteCode, room.Visibility, room.TurnTimerSeconds, room.BotDifficulty, room.PracticeMode, room.Status, room.CreatedBy, room.CreatedAt).
-		Scan(&room.ID, &room.InviteCode, &room.Visibility, &room.TurnTimerSeconds, &room.BotDifficulty, &room.PracticeMode, &room.Status, &room.CreatedBy, &room.CreatedAt)
+		INSERT INTO rooms (id, invite_code, visibility, turn_timer_seconds, bot_difficulty, practice_mode, min_elo, max_elo, status, created_by, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		RETURNING id, invite_code, visibility, turn_timer_seconds, bot_difficulty, practice_mode, min_elo, max_elo, status, created_by, created_at
+	`, room.ID, room.InviteCode, room.Visibility, room.TurnTimerSeconds, room.BotDifficulty, room.PracticeMode, nullableInt(minElo), nullableInt(maxElo), room.Status, room.CreatedBy, room.CreatedAt).
+		Scan(&room.ID, &room.InviteCode, &room.Visibility, &room.TurnTimerSeconds, &room.BotDifficulty, &room.PracticeMode, scanIntPtr(&room.MinElo), scanIntPtr(&room.MaxElo), &room.Status, &room.CreatedBy, &room.CreatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("create room: %w", err)
 	}
@@ -147,7 +164,10 @@ func CreateRoom(db *sql.DB, visibility string, turnTimerSeconds int, botDifficul
 // or creates a default public room when none is available. The selection and join
 // happen in one transaction so concurrent quick-play calls cannot overfill a
 // room. It returns created=true when it had to create a fallback room.
-func QuickPlayRoom(db *sql.DB, userID uuid.UUID, displayName string) (room RoomWithPlayerCount, created bool, retErr error) {
+func QuickPlayRoom(db *sql.DB, opts QuickPlayOptions) (room RoomWithPlayerCount, created bool, retErr error) {
+	if opts.Ranked && opts.Rating == nil {
+		return room, false, ErrRoomRatingRestricted
+	}
 	tx, err := db.Begin()
 	if err != nil {
 		return room, false, fmt.Errorf("begin transaction: %w", err)
@@ -157,6 +177,22 @@ func QuickPlayRoom(db *sql.DB, userID uuid.UUID, displayName string) (room RoomW
 			retErr = errors.Join(retErr, tx.Rollback())
 		}
 	}()
+
+	var (
+		ratingArg any
+		minElo    *int
+		maxElo    *int
+	)
+	if opts.Ranked {
+		ratingArg = *opts.Rating
+		lo := *opts.Rating - RankedQuickPlayEloRange
+		if lo < 0 {
+			lo = 0
+		}
+		hi := *opts.Rating + RankedQuickPlayEloRange
+		minElo = &lo
+		maxElo = &hi
+	}
 
 	err = tx.QueryRow(`
 		WITH candidate AS (
@@ -168,6 +204,10 @@ func QuickPlayRoom(db *sql.DB, userID uuid.UUID, displayName string) (room RoomW
 			  AND r.turn_timer_seconds = $1
 			  AND r.bot_difficulty = $2
 			  AND (SELECT COUNT(*) FROM room_players rp WHERE rp.room_id = r.id) < 4
+			  AND (
+			      ($4::boolean = false AND r.min_elo IS NULL AND r.max_elo IS NULL)
+			      OR ($4::boolean = true AND r.min_elo IS NOT NULL AND r.max_elo IS NOT NULL AND r.min_elo <= $5::integer AND r.max_elo >= $5::integer)
+			  )
 			  AND NOT EXISTS (
 			      SELECT 1 FROM room_players existing
 			      WHERE existing.room_id = r.id AND existing.user_id = $3
@@ -176,12 +216,12 @@ func QuickPlayRoom(db *sql.DB, userID uuid.UUID, displayName string) (room RoomW
 			LIMIT 1
 			FOR UPDATE SKIP LOCKED
 		)
-		SELECT r.id, r.invite_code, r.visibility, r.turn_timer_seconds, r.bot_difficulty, r.practice_mode, r.status, r.created_by, r.created_at,
+		SELECT r.id, r.invite_code, r.visibility, r.turn_timer_seconds, r.bot_difficulty, r.practice_mode, r.min_elo, r.max_elo, r.status, r.created_by, r.created_at,
 		       (SELECT COUNT(*) FROM room_players rp WHERE rp.room_id = r.id) AS player_count
 		FROM rooms r
 		JOIN candidate ON candidate.id = r.id
-	`, QuickPlayTurnTimerSeconds, QuickPlayBotDifficulty, userID).Scan(
-		&room.ID, &room.InviteCode, &room.Visibility, &room.TurnTimerSeconds, &room.BotDifficulty, &room.PracticeMode, &room.Status, &room.CreatedBy, &room.CreatedAt, &room.PlayerCount,
+	`, QuickPlayTurnTimerSeconds, QuickPlayBotDifficulty, opts.UserID, opts.Ranked, ratingArg).Scan(
+		&room.ID, &room.InviteCode, &room.Visibility, &room.TurnTimerSeconds, &room.BotDifficulty, &room.PracticeMode, scanIntPtr(&room.MinElo), scanIntPtr(&room.MaxElo), &room.Status, &room.CreatedBy, &room.CreatedAt, &room.PlayerCount,
 	)
 	if err != nil && err != sql.ErrNoRows {
 		return room, false, fmt.Errorf("find quick-play room: %w", err)
@@ -192,19 +232,19 @@ func QuickPlayRoom(db *sql.DB, userID uuid.UUID, displayName string) (room RoomW
 		if err != nil {
 			return room, false, err
 		}
-		room = RoomWithPlayerCount{Room: Room{ID: uuid.New(), InviteCode: inviteCode, Visibility: "public", TurnTimerSeconds: QuickPlayTurnTimerSeconds, BotDifficulty: QuickPlayBotDifficulty, PracticeMode: false, Status: "waiting", CreatedBy: userID, CreatedAt: time.Now()}}
+		room = RoomWithPlayerCount{Room: Room{ID: uuid.New(), InviteCode: inviteCode, Visibility: "public", TurnTimerSeconds: QuickPlayTurnTimerSeconds, BotDifficulty: QuickPlayBotDifficulty, PracticeMode: false, MinElo: minElo, MaxElo: maxElo, Status: "waiting", CreatedBy: opts.UserID, CreatedAt: time.Now()}}
 		if err := tx.QueryRow(`
-			INSERT INTO rooms (id, invite_code, visibility, turn_timer_seconds, bot_difficulty, practice_mode, status, created_by, created_at)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-			RETURNING id, invite_code, visibility, turn_timer_seconds, bot_difficulty, practice_mode, status, created_by, created_at
-		`, room.ID, room.InviteCode, room.Visibility, room.TurnTimerSeconds, room.BotDifficulty, room.PracticeMode, room.Status, room.CreatedBy, room.CreatedAt).
-			Scan(&room.ID, &room.InviteCode, &room.Visibility, &room.TurnTimerSeconds, &room.BotDifficulty, &room.PracticeMode, &room.Status, &room.CreatedBy, &room.CreatedAt); err != nil {
+			INSERT INTO rooms (id, invite_code, visibility, turn_timer_seconds, bot_difficulty, practice_mode, min_elo, max_elo, status, created_by, created_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+			RETURNING id, invite_code, visibility, turn_timer_seconds, bot_difficulty, practice_mode, min_elo, max_elo, status, created_by, created_at
+		`, room.ID, room.InviteCode, room.Visibility, room.TurnTimerSeconds, room.BotDifficulty, room.PracticeMode, nullableInt(room.MinElo), nullableInt(room.MaxElo), room.Status, room.CreatedBy, room.CreatedAt).
+			Scan(&room.ID, &room.InviteCode, &room.Visibility, &room.TurnTimerSeconds, &room.BotDifficulty, &room.PracticeMode, scanIntPtr(&room.MinElo), scanIntPtr(&room.MaxElo), &room.Status, &room.CreatedBy, &room.CreatedAt); err != nil {
 			return room, false, fmt.Errorf("create quick-play room: %w", err)
 		}
 		created = true
 	}
 
-	if _, err := tx.Exec(`INSERT INTO room_players (id, room_id, user_id, display_name, joined_at) VALUES ($1, $2, $3, $4, $5)`, uuid.New(), room.ID, userID, displayName, time.Now()); err != nil {
+	if _, err := tx.Exec(`INSERT INTO room_players (id, room_id, user_id, display_name, joined_at) VALUES ($1, $2, $3, $4, $5)`, uuid.New(), room.ID, opts.UserID, opts.DisplayName, time.Now()); err != nil {
 		return room, created, fmt.Errorf("join quick-play room: %w", err)
 	}
 	room.PlayerCount++
@@ -217,7 +257,7 @@ func QuickPlayRoom(db *sql.DB, userID uuid.UUID, displayName string) (room RoomW
 
 func GetPublicWaitingRooms(db *sql.DB) ([]RoomWithPlayerCount, error) {
 	rows, err := db.Query(`
-		SELECT r.id, r.invite_code, r.visibility, r.turn_timer_seconds, r.bot_difficulty, r.practice_mode, r.status, r.created_by, r.created_at,
+		SELECT r.id, r.invite_code, r.visibility, r.turn_timer_seconds, r.bot_difficulty, r.practice_mode, r.min_elo, r.max_elo, r.status, r.created_by, r.created_at,
 		       COUNT(rp.id) AS player_count
 		FROM rooms r
 		LEFT JOIN room_players rp ON rp.room_id = r.id
@@ -233,7 +273,7 @@ func GetPublicWaitingRooms(db *sql.DB) ([]RoomWithPlayerCount, error) {
 	rooms := []RoomWithPlayerCount{}
 	for rows.Next() {
 		var room RoomWithPlayerCount
-		if err := rows.Scan(&room.ID, &room.InviteCode, &room.Visibility, &room.TurnTimerSeconds, &room.BotDifficulty, &room.PracticeMode, &room.Status, &room.CreatedBy, &room.CreatedAt, &room.PlayerCount); err != nil {
+		if err := rows.Scan(&room.ID, &room.InviteCode, &room.Visibility, &room.TurnTimerSeconds, &room.BotDifficulty, &room.PracticeMode, scanIntPtr(&room.MinElo), scanIntPtr(&room.MaxElo), &room.Status, &room.CreatedBy, &room.CreatedAt, &room.PlayerCount); err != nil {
 			return nil, fmt.Errorf("scan room: %w", err)
 		}
 		rooms = append(rooms, room)
@@ -255,13 +295,13 @@ func GetRoomByID(db *sql.DB, id uuid.UUID) (*RoomWithPlayerCount, error) {
 func getRoom(db *sql.DB, where string, arg any) (*RoomWithPlayerCount, error) {
 	var room RoomWithPlayerCount
 	err := db.QueryRow(`
-		SELECT r.id, r.invite_code, r.visibility, r.turn_timer_seconds, r.bot_difficulty, r.practice_mode, r.status, r.created_by, r.created_at,
+		SELECT r.id, r.invite_code, r.visibility, r.turn_timer_seconds, r.bot_difficulty, r.practice_mode, r.min_elo, r.max_elo, r.status, r.created_by, r.created_at,
 		       COUNT(rp.id) AS player_count
 		FROM rooms r
 		LEFT JOIN room_players rp ON rp.room_id = r.id
 		`+where+`
 		GROUP BY r.id
-	`, arg).Scan(&room.ID, &room.InviteCode, &room.Visibility, &room.TurnTimerSeconds, &room.BotDifficulty, &room.PracticeMode, &room.Status, &room.CreatedBy, &room.CreatedAt, &room.PlayerCount)
+	`, arg).Scan(&room.ID, &room.InviteCode, &room.Visibility, &room.TurnTimerSeconds, &room.BotDifficulty, &room.PracticeMode, scanIntPtr(&room.MinElo), scanIntPtr(&room.MaxElo), &room.Status, &room.CreatedBy, &room.CreatedAt, &room.PlayerCount)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -271,7 +311,7 @@ func getRoom(db *sql.DB, where string, arg any) (*RoomWithPlayerCount, error) {
 	return &room, nil
 }
 
-func AddPlayerToRoom(db *sql.DB, roomID, userID uuid.UUID, displayName string) (playerCount int, retErr error) {
+func AddPlayerToRoom(db *sql.DB, roomID uuid.UUID, player JoinRoomPlayer) (playerCount int, retErr error) {
 	tx, err := db.Begin()
 	if err != nil {
 		return 0, fmt.Errorf("begin transaction: %w", err)
@@ -284,8 +324,9 @@ func AddPlayerToRoom(db *sql.DB, roomID, userID uuid.UUID, displayName string) (
 
 	var status string
 	var currentPlayerCount int
-	err = tx.QueryRow(`SELECT status, (SELECT COUNT(*) FROM room_players WHERE room_id = $1) FROM rooms WHERE id = $1 FOR UPDATE`, roomID).
-		Scan(&status, &currentPlayerCount)
+	var minElo, maxElo sql.NullInt64
+	err = tx.QueryRow(`SELECT status, min_elo, max_elo, (SELECT COUNT(*) FROM room_players WHERE room_id = $1) FROM rooms WHERE id = $1 FOR UPDATE`, roomID).
+		Scan(&status, &minElo, &maxElo, &currentPlayerCount)
 	if err != nil {
 		return 0, fmt.Errorf("check room: %w", err)
 	}
@@ -295,9 +336,14 @@ func AddPlayerToRoom(db *sql.DB, roomID, userID uuid.UUID, displayName string) (
 	if currentPlayerCount >= 4 {
 		return 0, ErrRoomFull
 	}
+	if minElo.Valid || maxElo.Valid {
+		if player.Rating == nil || !minElo.Valid || !maxElo.Valid || *player.Rating < int(minElo.Int64) || *player.Rating > int(maxElo.Int64) {
+			return 0, ErrRoomRatingRestricted
+		}
+	}
 
 	var existing int
-	err = tx.QueryRow(`SELECT COUNT(*) FROM room_players WHERE room_id = $1 AND user_id = $2`, roomID, userID).Scan(&existing)
+	err = tx.QueryRow(`SELECT COUNT(*) FROM room_players WHERE room_id = $1 AND user_id = $2`, roomID, player.UserID).Scan(&existing)
 	if err != nil {
 		return 0, fmt.Errorf("check existing player: %w", err)
 	}
@@ -305,7 +351,7 @@ func AddPlayerToRoom(db *sql.DB, roomID, userID uuid.UUID, displayName string) (
 		return 0, ErrPlayerAlreadyInRoom
 	}
 
-	_, err = tx.Exec(`INSERT INTO room_players (id, room_id, user_id, display_name, joined_at) VALUES ($1, $2, $3, $4, $5)`, uuid.New(), roomID, userID, displayName, time.Now())
+	_, err = tx.Exec(`INSERT INTO room_players (id, room_id, user_id, display_name, joined_at) VALUES ($1, $2, $3, $4, $5)`, uuid.New(), roomID, player.UserID, player.DisplayName, time.Now())
 	if err != nil {
 		return 0, fmt.Errorf("add player: %w", err)
 	}
@@ -315,6 +361,53 @@ func AddPlayerToRoom(db *sql.DB, roomID, userID uuid.UUID, displayName string) (
 		return 0, fmt.Errorf("commit: %w", err)
 	}
 	return newCount, nil
+}
+
+func GetUserRating(db *sql.DB, userID uuid.UUID) (int, error) {
+	var rating int
+	err := db.QueryRow(`SELECT rating FROM user_stats WHERE user_id = $1`, userID).Scan(&rating)
+	if err == sql.ErrNoRows {
+		return DefaultRating, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("get user rating: %w", err)
+	}
+	return rating, nil
+}
+
+func nullableInt(v *int) any {
+	if v == nil {
+		return nil
+	}
+	return *v
+}
+
+func scanIntPtr(target **int) any {
+	return &nullableIntScanner{target: target}
+}
+
+type nullableIntScanner struct {
+	target **int
+}
+
+func (s *nullableIntScanner) Scan(value any) error {
+	if value == nil {
+		*s.target = nil
+		return nil
+	}
+	var out int
+	switch v := value.(type) {
+	case int64:
+		out = int(v)
+	case int32:
+		out = int(v)
+	case int:
+		out = v
+	default:
+		return fmt.Errorf("scan nullable int: unsupported %T", value)
+	}
+	*s.target = &out
+	return nil
 }
 
 // RemovePlayerFromRoom drops a player's membership row. When the room is left

--- a/services/api/internal/repository/room_test.go
+++ b/services/api/internal/repository/room_test.go
@@ -66,16 +66,16 @@ func TestQuickPlayRoomJoinsOldestCompatibleRoom(t *testing.T) {
 	createdAt := time.Date(2026, 6, 8, 9, 0, 0, 0, time.UTC)
 
 	mock.ExpectBegin()
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT r.id, r.invite_code, r.visibility")).
-		WithArgs(QuickPlayTurnTimerSeconds, QuickPlayBotDifficulty, userID).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "invite_code", "visibility", "turn_timer_seconds", "bot_difficulty", "practice_mode", "status", "created_by", "created_at", "player_count"}).
-			AddRow(roomID, "OLD123", "public", 60, "medium", false, "waiting", createdBy, createdAt, 2))
+	mock.ExpectQuery(regexp.QuoteMeta("WITH candidate AS")).
+		WithArgs(QuickPlayTurnTimerSeconds, QuickPlayBotDifficulty, userID, false, nil).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "invite_code", "visibility", "turn_timer_seconds", "bot_difficulty", "practice_mode", "min_elo", "max_elo", "status", "created_by", "created_at", "player_count"}).
+			AddRow(roomID, "OLD123", "public", 60, "medium", false, nil, nil, "waiting", createdBy, createdAt, 2))
 	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO room_players")).
 		WithArgs(sqlmock.AnyArg(), roomID, userID, "Alice", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
-	room, created, err := QuickPlayRoom(db, userID, "Alice")
+	room, created, err := QuickPlayRoom(db, QuickPlayOptions{UserID: userID, DisplayName: "Alice"})
 	if err != nil {
 		t.Fatalf("QuickPlayRoom: %v", err)
 	}
@@ -101,19 +101,19 @@ func TestQuickPlayRoomCreatesDefaultRoomWhenNoneMatch(t *testing.T) {
 	createdAt := time.Date(2026, 6, 8, 9, 0, 0, 0, time.UTC)
 
 	mock.ExpectBegin()
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT r.id, r.invite_code, r.visibility")).
-		WithArgs(QuickPlayTurnTimerSeconds, QuickPlayBotDifficulty, userID).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "invite_code", "visibility", "turn_timer_seconds", "bot_difficulty", "practice_mode", "status", "created_by", "created_at", "player_count"}))
+	mock.ExpectQuery(regexp.QuoteMeta("WITH candidate AS")).
+		WithArgs(QuickPlayTurnTimerSeconds, QuickPlayBotDifficulty, userID, false, nil).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "invite_code", "visibility", "turn_timer_seconds", "bot_difficulty", "practice_mode", "min_elo", "max_elo", "status", "created_by", "created_at", "player_count"}))
 	mock.ExpectQuery(regexp.QuoteMeta("INSERT INTO rooms")).
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), "public", QuickPlayTurnTimerSeconds, QuickPlayBotDifficulty, false, "waiting", userID, sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "invite_code", "visibility", "turn_timer_seconds", "bot_difficulty", "practice_mode", "status", "created_by", "created_at"}).
-			AddRow(uuid.New(), "NEW123", "public", 60, "medium", false, "waiting", userID, createdAt))
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), "public", QuickPlayTurnTimerSeconds, QuickPlayBotDifficulty, false, nil, nil, "waiting", userID, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "invite_code", "visibility", "turn_timer_seconds", "bot_difficulty", "practice_mode", "min_elo", "max_elo", "status", "created_by", "created_at"}).
+			AddRow(uuid.New(), "NEW123", "public", 60, "medium", false, nil, nil, "waiting", userID, createdAt))
 	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO room_players")).
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), userID, "Alice", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
-	room, created, err := QuickPlayRoom(db, userID, "Alice")
+	room, created, err := QuickPlayRoom(db, QuickPlayOptions{UserID: userID, DisplayName: "Alice"})
 	if err != nil {
 		t.Fatalf("QuickPlayRoom: %v", err)
 	}
@@ -128,6 +128,54 @@ func TestQuickPlayRoomCreatesDefaultRoomWhenNoneMatch(t *testing.T) {
 	}
 }
 
+func TestQuickPlayRoomRankedCreatesRatingBoundedRoom(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	userID := uuid.New()
+	rating := 1234
+	createdAt := time.Date(2026, 6, 8, 9, 0, 0, 0, time.UTC)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("WITH candidate AS")).
+		WithArgs(QuickPlayTurnTimerSeconds, QuickPlayBotDifficulty, userID, true, rating).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "invite_code", "visibility", "turn_timer_seconds", "bot_difficulty", "practice_mode", "min_elo", "max_elo", "status", "created_by", "created_at", "player_count"}))
+	mock.ExpectQuery(regexp.QuoteMeta("INSERT INTO rooms")).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), "public", QuickPlayTurnTimerSeconds, QuickPlayBotDifficulty, false, 1034, 1434, "waiting", userID, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "invite_code", "visibility", "turn_timer_seconds", "bot_difficulty", "practice_mode", "min_elo", "max_elo", "status", "created_by", "created_at"}).
+			AddRow(uuid.New(), "RANKED", "public", 60, "medium", false, 1034, 1434, "waiting", userID, createdAt))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO room_players")).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), userID, "Alice", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	room, created, err := QuickPlayRoom(db, QuickPlayOptions{UserID: userID, DisplayName: "Alice", Rating: &rating, Ranked: true})
+	if err != nil {
+		t.Fatalf("QuickPlayRoom: %v", err)
+	}
+	if !created || room.MinElo == nil || room.MaxElo == nil || *room.MinElo != 1034 || *room.MaxElo != 1434 {
+		t.Fatalf("room = %+v created=%v", room, created)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestQuickPlayRoomRankedRequiresRating(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	if _, _, err := QuickPlayRoom(db, QuickPlayOptions{UserID: uuid.New(), DisplayName: "Guest", Ranked: true}); err != ErrRoomRatingRestricted {
+		t.Fatalf("err = %v, want ErrRoomRatingRestricted", err)
+	}
+}
+
 func TestQuickPlayRoomPropagatesSelectionError(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -137,12 +185,12 @@ func TestQuickPlayRoomPropagatesSelectionError(t *testing.T) {
 
 	userID := uuid.New()
 	mock.ExpectBegin()
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT r.id, r.invite_code, r.visibility")).
-		WithArgs(QuickPlayTurnTimerSeconds, QuickPlayBotDifficulty, userID).
+	mock.ExpectQuery(regexp.QuoteMeta("WITH candidate AS")).
+		WithArgs(QuickPlayTurnTimerSeconds, QuickPlayBotDifficulty, userID, false, nil).
 		WillReturnError(sqlmock.ErrCancelled)
 	mock.ExpectRollback()
 
-	if _, _, err := QuickPlayRoom(db, userID, "Alice"); err == nil {
+	if _, _, err := QuickPlayRoom(db, QuickPlayOptions{UserID: userID, DisplayName: "Alice"}); err == nil {
 		t.Fatal("expected query error to propagate")
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -183,11 +231,11 @@ func TestCreateRoomPersistsPracticeMode(t *testing.T) {
 	now := time.Date(2026, 6, 7, 10, 0, 0, 0, time.UTC)
 
 	mock.ExpectQuery(regexp.QuoteMeta("INSERT INTO rooms")).
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), "private", 60, "hard", true, "waiting", createdBy, sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "invite_code", "visibility", "turn_timer_seconds", "bot_difficulty", "practice_mode", "status", "created_by", "created_at"}).
-			AddRow(uuid.New(), "PRAC01", "private", 60, "hard", true, "waiting", createdBy, now))
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), "private", 60, "hard", true, nil, nil, "waiting", createdBy, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "invite_code", "visibility", "turn_timer_seconds", "bot_difficulty", "practice_mode", "min_elo", "max_elo", "status", "created_by", "created_at"}).
+			AddRow(uuid.New(), "PRAC01", "private", 60, "hard", true, nil, nil, "waiting", createdBy, now))
 
-	room, err := CreateRoom(db, "private", 60, "hard", true, createdBy)
+	room, err := CreateRoom(db, "private", 60, "hard", true, nil, nil, createdBy)
 	if err != nil {
 		t.Fatalf("CreateRoom: %v", err)
 	}
@@ -199,5 +247,54 @@ func TestCreateRoomPersistsPracticeMode(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestCreateRoomPersistsEloRange(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	createdBy := uuid.New()
+	minElo, maxElo := 1000, 1400
+	now := time.Date(2026, 6, 7, 10, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta("INSERT INTO rooms")).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), "public", 60, "medium", false, minElo, maxElo, "waiting", createdBy, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "invite_code", "visibility", "turn_timer_seconds", "bot_difficulty", "practice_mode", "min_elo", "max_elo", "status", "created_by", "created_at"}).
+			AddRow(uuid.New(), "ELO123", "public", 60, "medium", false, minElo, maxElo, "waiting", createdBy, now))
+
+	room, err := CreateRoom(db, "public", 60, "medium", false, &minElo, &maxElo, createdBy)
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	if room.MinElo == nil || room.MaxElo == nil || *room.MinElo != minElo || *room.MaxElo != maxElo {
+		t.Fatalf("elo range = %v-%v", room.MinElo, room.MaxElo)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestGetUserRatingDefaultsWhenNoStats(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	userID := uuid.New()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT rating FROM user_stats")).
+		WithArgs(userID).
+		WillReturnRows(sqlmock.NewRows([]string{"rating"}))
+
+	rating, err := GetUserRating(db, userID)
+	if err != nil {
+		t.Fatalf("GetUserRating: %v", err)
+	}
+	if rating != DefaultRating {
+		t.Fatalf("rating = %d, want %d", rating, DefaultRating)
 	}
 }

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -86,8 +86,21 @@ beforeEach(() => {
       visibility: 'public',
       turn_timer_seconds: 60,
       bot_difficulty: 'medium',
+      min_elo: null,
+      max_elo: null,
       status: 'waiting',
       player_count: 3,
+    },
+    {
+      id: 'ranked-room',
+      invite_code: 'RANKED',
+      visibility: 'public',
+      turn_timer_seconds: 60,
+      bot_difficulty: 'medium',
+      min_elo: 1000,
+      max_elo: 1400,
+      status: 'waiting',
+      player_count: 2,
     },
   ])
   vi.mocked(postRoom).mockResolvedValue({
@@ -96,6 +109,8 @@ beforeEach(() => {
     visibility: 'public',
     turn_timer_seconds: 60,
     bot_difficulty: 'medium',
+    min_elo: null,
+    max_elo: null,
     status: 'waiting',
     player_count: 1,
   })
@@ -117,6 +132,8 @@ beforeEach(() => {
     visibility: 'public',
     turn_timer_seconds: 60,
     bot_difficulty: 'medium',
+    min_elo: null,
+    max_elo: null,
     status: 'waiting',
     player_count: 1,
   })
@@ -370,10 +387,10 @@ test('quick play finds a room and navigates to the waiting room', async () => {
   renderRoute('/lobby')
 
   await waitFor(() => {
-    expect(screen.getByRole('button', { name: /Quick Play/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^Quick Play$/i })).toBeInTheDocument()
   })
 
-  fireEvent.click(screen.getByRole('button', { name: /Quick Play/i }))
+  fireEvent.click(screen.getByRole('button', { name: /^Quick Play$/i }))
 
   await waitFor(() => {
     expect(postQuickPlay).toHaveBeenCalledWith('test-token')
@@ -383,15 +400,39 @@ test('quick play finds a room and navigates to the waiting room', async () => {
   })
 })
 
+test('ranked quick play sends ranked matchmaking request', async () => {
+  renderRoute('/lobby')
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: /Ranked Quick Play/i })).toBeInTheDocument()
+  })
+
+  fireEvent.click(screen.getByRole('button', { name: /Ranked Quick Play/i }))
+
+  await waitFor(() => {
+    expect(postQuickPlay).toHaveBeenCalledWith('test-token', { ranked: true })
+  })
+})
+
+test('lobby separates rating-matched rooms from open rooms', async () => {
+  renderRoute('/lobby')
+
+  await waitFor(() => {
+    expect(screen.getByRole('heading', { name: /Rating-matched rooms/i })).toBeInTheDocument()
+  })
+  expect(screen.getByText(/ELO 1000-1400/i)).toBeInTheDocument()
+  expect(screen.getByRole('heading', { name: /Open rooms/i })).toBeInTheDocument()
+})
+
 test('quick play shows an error when matchmaking fails', async () => {
   vi.mocked(postQuickPlay).mockRejectedValueOnce(new Error('Too many attempts'))
   renderRoute('/lobby')
 
   await waitFor(() => {
-    expect(screen.getByRole('button', { name: /Quick Play/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^Quick Play$/i })).toBeInTheDocument()
   })
 
-  fireEvent.click(screen.getByRole('button', { name: /Quick Play/i }))
+  fireEvent.click(screen.getByRole('button', { name: /^Quick Play$/i }))
 
   await waitFor(() => {
     expect(screen.getByRole('alert')).toHaveTextContent('Too many attempts')

--- a/web/src/api/lobby.ts
+++ b/web/src/api/lobby.ts
@@ -11,6 +11,8 @@ export type RoomDto = {
   turn_timer_seconds: number
   bot_difficulty: BotDifficulty
   practice_mode: boolean
+  min_elo: number | null
+  max_elo: number | null
   status: RoomStatus
   player_count: number
 }
@@ -20,6 +22,12 @@ export type CreateRoomRequest = {
   turn_timer_seconds: number
   bot_difficulty: BotDifficulty
   practice_mode?: boolean
+  min_elo?: number
+  max_elo?: number
+}
+
+export type QuickPlayRequest = {
+  ranked?: boolean
 }
 
 export type JoinRoomResponse = {
@@ -52,9 +60,10 @@ export function postJoinRoom(token: string | null, inviteCode: string): Promise<
   })
 }
 
-export function postQuickPlay(token: string | null): Promise<JoinRoomResponse> {
+export function postQuickPlay(token: string | null, body?: QuickPlayRequest): Promise<JoinRoomResponse> {
   return apiRequest<JoinRoomResponse>('/rooms/quick-play', {
     method: 'POST',
     token,
+    body,
   })
 }

--- a/web/src/components/RoomCard.tsx
+++ b/web/src/components/RoomCard.tsx
@@ -33,6 +33,12 @@ export function RoomCard({ room, onJoin }: { room: Room; onJoin?: () => void }) 
         <span>{room.players} · {room.timer} · Bots: {room.botDifficulty}</span>
       </div>
 
+      {room.eloRange ? (
+        <div className="font-mono text-[11px] uppercase tracking-[0.12em] text-spade-gold-light">
+          {room.eloRange}
+        </div>
+      ) : null}
+
       <Button
         variant={room.open ? 'primary' : 'secondary'}
         disabled={!room.open}

--- a/web/src/pages/LobbyPage.tsx
+++ b/web/src/pages/LobbyPage.tsx
@@ -16,6 +16,7 @@ import {
   type RoomDto,
   type RoomVisibility,
 } from '../api/lobby'
+import { getMyStats } from '../api/stats'
 import { useAuth } from '../hooks/useAuth'
 import { getLiveGames, type LiveGameDto } from '../api/liveGames'
 import { FriendsPanel } from '../components/FriendsPanel'
@@ -32,6 +33,7 @@ function botDifficultyLabel(value: BotDifficulty): string {
 
 function roomDtoToRoom(dto: RoomDto): Room {
   const fillStatus = dto.player_count >= 4 ? 'Full' : `${dto.player_count} / 4 players`
+  const eloRange = dto.min_elo !== null && dto.max_elo !== null ? `ELO ${dto.min_elo}-${dto.max_elo}` : undefined
   return {
     name: dto.visibility === 'private' ? 'Private room' : 'Public room',
     code: dto.invite_code,
@@ -39,6 +41,7 @@ function roomDtoToRoom(dto: RoomDto): Room {
     status: dto.status === 'waiting' ? fillStatus : `Status: ${dto.status}`,
     timer: `${dto.turn_timer_seconds}s`,
     botDifficulty: botDifficultyLabel(dto.bot_difficulty),
+    eloRange,
     open: dto.status === 'waiting' && dto.player_count < 4,
     filledSeats: Math.min(dto.player_count, 4),
     maxSeats: 4,
@@ -65,6 +68,9 @@ export function LobbyPage() {
   const [visibility, setVisibility] = useState<RoomVisibility>('public')
   const [timer, setTimer] = useState<30 | 60 | 90 | 120>(60)
   const [botDifficulty, setBotDifficulty] = useState<BotDifficulty>('medium')
+  const [limitByRating, setLimitByRating] = useState(false)
+  const [minElo, setMinElo] = useState(1000)
+  const [maxElo, setMaxElo] = useState(1400)
   const [isCreating, setIsCreating] = useState(false)
   const [createError, setCreateError] = useState<string | null>(null)
   const [showCreate, setShowCreate] = useState(false)
@@ -81,7 +87,9 @@ export function LobbyPage() {
   const [practiceError, setPracticeError] = useState<string | null>(null)
 
   const [isQuickPlaying, setIsQuickPlaying] = useState(false)
+  const [isRankedQuickPlaying, setIsRankedQuickPlaying] = useState(false)
   const [quickPlayToasts, setQuickPlayToasts] = useState<Toast[]>([])
+  const [myRating, setMyRating] = useState<number | null>(null)
 
   const [refreshNonce, setRefreshNonce] = useState(0)
   const [searchParams, setSearchParams] = useSearchParams()
@@ -185,6 +193,21 @@ export function LobbyPage() {
   // errors) run with the loading indicator shown.
   useEffect(() => loadRooms(false), [loadRooms, refreshNonce])
 
+  useEffect(() => {
+    if (!isAuthenticated || isGuest) return
+    let cancelled = false
+    getMyStats(token)
+      .then((stats) => {
+        if (!cancelled) setMyRating(stats.rating)
+      })
+      .catch(() => {
+        if (!cancelled) setMyRating(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [isAuthenticated, isGuest, token])
+
   // Load in-progress public games to watch, on the same cadence as the room
   // list. Failures are non-fatal: the watch section just stays empty.
   const loadLiveGames = useCallback(() => {
@@ -228,6 +251,7 @@ export function LobbyPage() {
         visibility,
         turn_timer_seconds: timer,
         bot_difficulty: botDifficulty,
+        ...(limitByRating && visibility === 'public' ? { min_elo: minElo, max_elo: maxElo } : {}),
       })
       navigate(`/room/${created.id}`)
     } catch (err) {
@@ -280,8 +304,30 @@ export function LobbyPage() {
     }
   }
 
+  const handleRankedQuickPlay = async () => {
+    setQuickPlayToasts([])
+    setJoinError(null)
+    if (isGuest) {
+      pushQuickPlayToast({ tone: 'error', title: 'Ranked Quick Play unavailable', body: 'Sign in to use rating-based matchmaking.' })
+      return
+    }
+    setIsRankedQuickPlaying(true)
+    try {
+      const joined = await postQuickPlay(token, { ranked: true })
+      navigate(`/room/${joined.id}`)
+    } catch (err) {
+      pushQuickPlayToast({ tone: 'error', title: 'Ranked Quick Play failed', body: getErrorMessage(err, 'Failed to find a ranked game') })
+    } finally {
+      setIsRankedQuickPlaying(false)
+    }
+  }
+
   const openCreate = () => {
     setCreateError(null)
+    if (myRating !== null) {
+      setMinElo(Math.max(0, myRating - 200))
+      setMaxElo(myRating + 200)
+    }
     setShowCreate(true)
   }
 
@@ -315,6 +361,10 @@ export function LobbyPage() {
   }
 
   const openRoomCount = rooms.filter((room) => room.status === 'waiting' && room.player_count < 4).length
+  const isConstrainedRoom = (room: RoomDto) => room.min_elo !== null && room.max_elo !== null
+  const matchesMyRating = (room: RoomDto) => myRating !== null && room.min_elo !== null && room.max_elo !== null && myRating >= room.min_elo && myRating <= room.max_elo
+  const ratingMatchedRooms = rooms.filter((room) => isConstrainedRoom(room) && matchesMyRating(room))
+  const openRooms = rooms.filter((room) => !isConstrainedRoom(room))
 
   return (
     <SceneShell
@@ -325,6 +375,9 @@ export function LobbyPage() {
           <Badge tone="waiting">{`${openRoomCount} waiting`}</Badge>
           <Button onClick={() => void handleQuickPlay()} disabled={isQuickPlaying}>
             {isQuickPlaying ? 'Finding game…' : 'Quick Play'}
+          </Button>
+          <Button variant="ghost" onClick={() => void handleRankedQuickPlay()} disabled={isRankedQuickPlaying || isGuest}>
+            {isRankedQuickPlaying ? 'Finding ranked game…' : 'Ranked Quick Play'}
           </Button>
           <Button onClick={openPractice}>Practice</Button>
           <Button variant="secondary" onClick={openCreate}>Create room</Button>
@@ -365,16 +418,25 @@ export function LobbyPage() {
             <Button className="mt-4" onClick={openCreate}>Create room</Button>
           </div>
         ) : null}
-        {rooms.length > 0 ? (
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {rooms.map((room) => (
-              <RoomCard
-                key={room.id}
-                room={roomDtoToRoom(room)}
-                onJoin={() => void handleJoinPublic(room)}
-              />
-            ))}
-          </div>
+        {ratingMatchedRooms.length > 0 ? (
+          <section className="grid gap-3">
+            <h3 className="text-sm font-medium text-spade-gray-2">Rating-matched rooms</h3>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {ratingMatchedRooms.map((room) => (
+                <RoomCard key={room.id} room={roomDtoToRoom(room)} onJoin={() => void handleJoinPublic(room)} />
+              ))}
+            </div>
+          </section>
+        ) : null}
+        {openRooms.length > 0 ? (
+          <section className="grid gap-3">
+            <h3 className="text-sm font-medium text-spade-gray-2">Open rooms</h3>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {openRooms.map((room) => (
+                <RoomCard key={room.id} room={roomDtoToRoom(room)} onJoin={() => void handleJoinPublic(room)} />
+              ))}
+            </div>
+          </section>
         ) : null}
 
         {liveGames.length > 0 ? (
@@ -476,6 +538,44 @@ export function LobbyPage() {
                 ))}
               </div>
             </div>
+
+            {visibility === 'public' ? (
+              <div className="grid gap-3 rounded-spade-md border border-spade-cream/10 bg-spade-bg/45 p-3">
+                <label className="flex items-center gap-2 text-sm text-spade-gray-2">
+                  <input
+                    type="checkbox"
+                    checked={limitByRating}
+                    onChange={(event) => setLimitByRating(event.target.checked)}
+                    className="size-4 accent-spade-gold"
+                  />
+                  Limit room by rating
+                </label>
+                {limitByRating ? (
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <label className="grid gap-1.5 text-xs font-medium uppercase text-spade-gray-2">
+                      Min rating
+                      <input
+                        type="number"
+                        min={0}
+                        value={minElo}
+                        onChange={(event) => setMinElo(Number(event.target.value))}
+                        className="rounded-spade-md border border-spade-gray-4/60 bg-spade-bg px-3 py-2 text-sm text-spade-cream outline-none focus:border-spade-gold focus:ring-2 focus:ring-spade-gold/20"
+                      />
+                    </label>
+                    <label className="grid gap-1.5 text-xs font-medium uppercase text-spade-gray-2">
+                      Max rating
+                      <input
+                        type="number"
+                        min={0}
+                        value={maxElo}
+                        onChange={(event) => setMaxElo(Number(event.target.value))}
+                        className="rounded-spade-md border border-spade-gray-4/60 bg-spade-bg px-3 py-2 text-sm text-spade-cream outline-none focus:border-spade-gold focus:ring-2 focus:ring-spade-gold/20"
+                      />
+                    </label>
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
 
             {createError ? (
               <p role="alert" className="text-xs text-spade-red">

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -37,6 +37,7 @@ export type Room = {
   status: string
   timer: string
   botDifficulty: string
+  eloRange?: string
   open: boolean
   filledSeats: number
   maxSeats: number


### PR DESCRIPTION
- Add migration 017_room_elo_constraints (min_elo/max_elo on rooms)
- POST /rooms accepts and returns ELO constraints
- Manual joins enforce rating constraints; guests blocked from rated rooms
- POST /rooms/quick-play accepts { ranked: true } for rating-based matchmaking
- Ranked Quick Play uses lifetime rating ±200 band, casual stays unconstrained
- Web/mobile: separate Quick Play and Ranked Quick Play buttons
- Web/mobile: lobby splits Rating-matched rooms from Open rooms with ELO badge
- Web: rating-limited room creation toggle in Create Room modal
- Mobile: matching rating-limited creation controls
- Update docs/specs/seasons-and-elo.md for Phase C shipped

Closes #43,  Phase 3