### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,6 +93,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions: {}
     environment: production
     steps:
       - name: Update Swarm services to the new tag


### PR DESCRIPTION
Potential fix for [https://github.com/faytranevozter/7spade/security/code-scanning/2](https://github.com/faytranevozter/7spade/security/code-scanning/2)

Add an explicit `permissions` block to the `deploy` job in `.github/workflows/deploy.yml` so the job does not inherit potentially broad defaults.  
Best minimal fix without changing behavior: set `permissions: {}` for `deploy`, because this job only performs SSH using secrets and does not require `GITHUB_TOKEN` scopes. This is stricter and avoids granting unnecessary access.

Change location:
- File: `.github/workflows/deploy.yml`
- Region: `jobs.deploy` block, right after `runs-on` (before `environment` is fine).

No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
