### PR TITLE
feat: display rating and XP gained after match

### DIFF
--- a/mobile/app/(app)/game/[id].tsx
+++ b/mobile/app/(app)/game/[id].tsx
@@ -372,6 +372,7 @@ function GameOverPanel({ roomId, game }: { roomId: string | undefined; game: Gam
           </View>
 
           <ScoreTable scores={scores} winnerLabel={winnerLabel} />
+          <MatchStatsCard results={game.results} myDisplayName={game.myDisplayName} practiceMode={game.practiceMode} />
           <RevealedPenaltyCards results={game.results} />
 
           <View className="rounded-spade-lg border border-spade-gold/30 bg-spade-gold/10 p-4">
@@ -405,6 +406,35 @@ function GameOverPanel({ roomId, game }: { roomId: string | undefined; game: Gam
           <ToastStack toasts={game.toasts} />
         </View>
       </SceneShell>
+    </View>
+  )
+}
+
+function MatchStatsCard({ results, myDisplayName, practiceMode }: { results: GameResult[]; myDisplayName: string | null; practiceMode: boolean }) {
+  if (practiceMode || !myDisplayName) return null
+  const myResult = results.find((r) => r.player === myDisplayName)
+  if (!myResult || myResult.xpDelta === undefined) return null
+
+  const ratingDelta = myResult.ratingDelta ?? 0
+  const ratingSign = ratingDelta >= 0 ? '+' : ''
+
+  return (
+    <View className="rounded-spade-lg border border-spade-cream/10 bg-[#2b302d] p-4">
+      <Text className="text-lg font-medium text-spade-cream">Your match rewards</Text>
+      <View className="mt-3 flex-row gap-3">
+        <View className="flex-1 rounded-spade-md border border-spade-cream/10 bg-spade-bg/45 p-3">
+          <Text className="font-mono text-[10px] uppercase text-spade-gray-3">XP gained</Text>
+          <Text className="mt-1 text-lg font-medium text-spade-gold-light">+{myResult.xpDelta}</Text>
+          <Text className="mt-0.5 font-mono text-xs text-spade-gray-2">Level {myResult.level}</Text>
+        </View>
+        <View className="flex-1 rounded-spade-md border border-spade-cream/10 bg-spade-bg/45 p-3">
+          <Text className="font-mono text-[10px] uppercase text-spade-gray-3">Rating</Text>
+          <Text className={`mt-1 text-lg font-medium ${ratingDelta > 0 ? 'text-green-400' : ratingDelta < 0 ? 'text-red-400' : 'text-spade-cream'}`}>
+            {ratingSign}{ratingDelta}
+          </Text>
+          <Text className="mt-0.5 font-mono text-xs text-spade-gray-2">{myResult.ratingAfter ?? '—'}</Text>
+        </View>
+      </View>
     </View>
   )
 }

--- a/mobile/src/hooks/useGameSocket.ts
+++ b/mobile/src/hooks/useGameSocket.ts
@@ -59,6 +59,11 @@ type GameOverMessage = {
     rank: number
     is_winner: boolean
     facedown_cards?: Array<{ suit: string; rank: string | number; points: number }>
+    rating_delta?: number
+    rating_after?: number
+    xp_delta?: number
+    xp_after?: number
+    level?: number
   }>
 }
 
@@ -815,6 +820,11 @@ function toGameResult(result: GameOverMessage['results'][number]): GameResult {
       ...toCard(card),
       points: card.points,
     })),
+    ratingDelta: result.rating_delta,
+    ratingAfter: result.rating_after,
+    xpDelta: result.xp_delta,
+    xpAfter: result.xp_after,
+    level: result.level,
   }
 }
 

--- a/mobile/src/types.ts
+++ b/mobile/src/types.ts
@@ -65,6 +65,11 @@ export type GameResult = {
   penalty: number
   winner: boolean
   faceDownCards: RevealedPenaltyCard[]
+  ratingDelta?: number
+  ratingAfter?: number
+  xpDelta?: number
+  xpAfter?: number
+  level?: number
 }
 
 export type ToastTone = 'success' | 'warn' | 'info' | 'error'

--- a/services/api/internal/handler/history.go
+++ b/services/api/internal/handler/history.go
@@ -45,13 +45,13 @@ func (h HistoryHandler) Save(c *gin.Context) {
 		JSONError(c, http.StatusBadRequest, "Invalid request body")
 		return
 	}
-	gameID, err := repository.SaveGame(h.DB, result)
+	saveResult, err := repository.SaveGame(h.DB, result)
 	if err != nil {
 		log.Printf("history: save game: %v", err)
 		JSONError(c, http.StatusInternalServerError, "Failed to save game: "+err.Error())
 		return
 	}
-	c.JSON(http.StatusCreated, gin.H{"game_id": gameID.String()})
+	c.JSON(http.StatusCreated, gin.H{"game_id": saveResult.GameID.String(), "deltas": saveResult.Deltas})
 }
 
 func positiveQueryInt(c *gin.Context, key string, fallback int) int {

--- a/services/api/internal/repository/game.go
+++ b/services/api/internal/repository/game.go
@@ -37,6 +37,20 @@ type HistoryGame struct {
 	IsWinner      bool   `json:"is_winner"`
 }
 
+type PlayerDelta struct {
+	UserID      string `json:"user_id"`
+	RatingDelta int    `json:"rating_delta"`
+	RatingAfter int    `json:"rating_after"`
+	XPDelta     int    `json:"xp_delta"`
+	XPAfter     int64  `json:"xp_after"`
+	Level       int    `json:"level"`
+}
+
+type GameSaveResult struct {
+	GameID uuid.UUID     `json:"game_id"`
+	Deltas []PlayerDelta `json:"deltas"`
+}
+
 // closeGameMargins are penalty thresholds (inclusive) that classify a finish as
 // "close" or a "blowout" relative to the winner / runner-up.
 const (
@@ -98,11 +112,12 @@ func (pen gamePenalties) flagsFor(p GameResultPlayer) closeGameStoryFlags {
 	}
 }
 
-func SaveGame(db *sql.DB, result GameResult) (uuid.UUID, error) {
+func SaveGame(db *sql.DB, result GameResult) (GameSaveResult, error) {
 	// Resolve (and lazily roll over) the active season before opening the save
 	// transaction, so the per-player season upsert and ELO update target the
 	// right bucket. A failure here is non-fatal: the all-time stats path must
 	// still record the game, so we fall back to an empty season id (skipped).
+	var empty GameSaveResult
 	seasonID := ""
 	if season, err := EnsureActiveSeason(db); err != nil {
 		log.Printf("ensure active season: %v", err)
@@ -112,7 +127,7 @@ func SaveGame(db *sql.DB, result GameResult) (uuid.UUID, error) {
 
 	tx, err := db.Begin()
 	if err != nil {
-		return uuid.Nil, fmt.Errorf("begin save game: %w", err)
+		return empty, fmt.Errorf("begin save game: %w", err)
 	}
 	committed := false
 	defer func() {
@@ -124,15 +139,10 @@ func SaveGame(db *sql.DB, result GameResult) (uuid.UUID, error) {
 	}()
 
 	gameID := uuid.New()
-	// Copy the room's current name into the game row so history keeps a friendly
-	// label even after the rooms row is deleted. Match on id::text to avoid
-	// casting room_id (which may be a non-UUID test value) to uuid; a missing
-	// room yields NULL.
 	if _, err := tx.Exec(`INSERT INTO games (id, room_id, room_name, started_at, finished_at) VALUES ($1, $2, (SELECT name FROM rooms WHERE id::text = $2), $3, $4)`, gameID, result.RoomID, result.StartedAt, result.FinishedAt); err != nil {
-		return uuid.Nil, fmt.Errorf("insert game: %w", err)
+		return empty, fmt.Errorf("insert game: %w", err)
 	}
 
-	// Determine game-level context before the per-player loop.
 	registeredWinners := 0
 	hasBot := false
 	for _, player := range result.Players {
@@ -145,20 +155,19 @@ func SaveGame(db *sql.DB, result GameResult) (uuid.UUID, error) {
 	}
 	sharedWin := registeredWinners > 1
 
-	// closeGamePenalties is computed over *all* players (including bots and
-	// guests), since the close-game / blowout margins describe the table
-	// outcome regardless of who is registered. A bot or guest can finish first,
-	// so anchoring these to registered players only would mis-stamp the flags.
 	pen := closeGamePenalties(result.Players)
 
-	// Collect registered players for the ELO pairwise calculation as we go.
 	eloPlayers := []EloPlayer{}
+	xpSnapshots := map[string]struct {
+		xpDelta int
+		xpAfter int64
+	}{}
 	for _, player := range result.Players {
 		var userID *uuid.UUID
 		if player.UserID != "" {
 			parsed, err := uuid.Parse(player.UserID)
 			if err != nil {
-				return uuid.Nil, fmt.Errorf("parse player user id: %w", err)
+				return empty, fmt.Errorf("parse player user id: %w", err)
 			}
 			userID = &parsed
 		}
@@ -167,17 +176,11 @@ func SaveGame(db *sql.DB, result GameResult) (uuid.UUID, error) {
 			VALUES ($1, $2, $3, $4, $5, $6, $7)
 		`, gameID, userID, player.DisplayName, player.PenaltyPoints, player.Rank, player.IsWinner, player.IsBot)
 		if err != nil {
-			return uuid.Nil, fmt.Errorf("insert game player: %w", err)
+			return empty, fmt.Errorf("insert game player: %w", err)
 		}
-		// Update lifetime stats for registered players only; guests/bots have a
-		// nil user_id and are skipped. Runs in the same transaction so stats
-		// never diverge from the underlying game_players rows on the happy path.
 		if userID != nil {
 			flags := pen.flagsFor(player)
 
-			// XP is awarded to registered players only and is folded into the
-			// stats upsert below so user_stats is touched once. The breakdown is
-			// recorded as an audit row after the upsert returns the new total.
 			xpDelta, xpBreakdown := CalculateXP(player, hasBot)
 
 			params := UpsertUserStatsParams{
@@ -194,18 +197,18 @@ func SaveGame(db *sql.DB, result GameResult) (uuid.UUID, error) {
 			}
 			snap, err := UpsertUserStats(tx, params)
 			if err != nil {
-				return uuid.Nil, err
+				return empty, err
 			}
-			// Audit the XP award. snap.XP is the post-update total, so
-			// xp_before = xp_after - delta stays consistent within the txn.
 			if err := insertXPEvent(tx, gameID, *userID, snap.XP, xpDelta, xpBreakdown); err != nil {
-				return uuid.Nil, err
+				return empty, err
 			}
-			// Mirror into the active season's bucket (Phase A). XP is
-			// lifetime-only, so UpsertSeasonUserStats ignores params.XPDelta.
+			xpSnapshots[userID.String()] = struct {
+				xpDelta int
+				xpAfter int64
+			}{xpDelta, snap.XP}
 			if seasonID != "" {
 				if err := UpsertSeasonUserStats(tx, seasonID, params); err != nil {
-					return uuid.Nil, err
+					return empty, err
 				}
 			}
 			eloPlayers = append(eloPlayers, EloPlayer{UserID: *userID, Rank: player.Rank})
@@ -222,40 +225,54 @@ func SaveGame(db *sql.DB, result GameResult) (uuid.UUID, error) {
 				HumanOnlyGames:    snap.HumanOnlyGames,
 			})
 			if err != nil {
-				return uuid.Nil, err
+				return empty, err
 			}
 			if err := AwardAchievements(tx, *userID, ids); err != nil {
-				return uuid.Nil, err
+				return empty, err
 			}
 		}
 	}
 
-	// Skill rating (Phase B): adjust the registered players' ELO from their
-	// finishing ranks via pairwise expansion. Needs >= 2 registered players to
-	// have anything to compare; a lone human among bots simply doesn't move.
 	eloDeltas := map[string]int{}
 	if len(eloPlayers) >= 2 {
 		eloDeltas, err = applyEloUpdates(tx, seasonID, eloPlayers)
 		if err != nil {
-			return uuid.Nil, err
+			return empty, err
 		}
 	}
 
-	// Insert rating events for every registered player (even when delta is 0).
-	// eloDeltas holds the lifetime delta, matching the user_stats.rating that
-	// insertRatingEvent reads back, so before/after/delta stay self-consistent.
 	for _, ep := range eloPlayers {
 		delta := eloDeltas[ep.UserID.String()]
 		if err := insertRatingEvent(tx, gameID, ep.UserID, delta); err != nil {
-			return uuid.Nil, err
+			return empty, err
 		}
 	}
 
 	if err := tx.Commit(); err != nil {
-		return uuid.Nil, fmt.Errorf("commit save game: %w", err)
+		return empty, fmt.Errorf("commit save game: %w", err)
 	}
 	committed = true
-	return gameID, nil
+
+	deltas := make([]PlayerDelta, 0, len(eloPlayers))
+	for _, ep := range eloPlayers {
+		uid := ep.UserID.String()
+		xpSnap := xpSnapshots[uid]
+		ratingDelta := eloDeltas[uid]
+		var ratingAfter int
+		if err := db.QueryRow(`SELECT rating FROM user_stats WHERE user_id = $1`, ep.UserID).Scan(&ratingAfter); err != nil {
+			ratingAfter = 1200 + ratingDelta
+		}
+		deltas = append(deltas, PlayerDelta{
+			UserID:      uid,
+			RatingDelta: ratingDelta,
+			RatingAfter: ratingAfter,
+			XPDelta:     xpSnap.xpDelta,
+			XPAfter:     xpSnap.xpAfter,
+			Level:       LevelFromXP(xpSnap.xpAfter),
+		})
+	}
+
+	return GameSaveResult{GameID: gameID, Deltas: deltas}, nil
 }
 
 // applyEloUpdates reads the current lifetime (and season) ratings for the given

--- a/services/ws/server.go
+++ b/services/ws/server.go
@@ -121,6 +121,7 @@ type room struct {
 	rematchTimerToken int
 	kickedSubs        map[string]bool
 	spectators        []*spectator
+	gameDeltas        map[string]playerDelta
 	mu                sync.Mutex
 
 	// roomRelay is set when the server is running with cross-replica relay
@@ -214,7 +215,16 @@ func normalizeBotDifficulty(value string) game.BotDifficulty {
 }
 
 type gameHistoryStore interface {
-	SaveGame(result savedGameResult) error
+	SaveGame(result savedGameResult) ([]playerDelta, error)
+}
+
+type playerDelta struct {
+	UserID      string `json:"user_id"`
+	RatingDelta int    `json:"rating_delta"`
+	RatingAfter int    `json:"rating_after"`
+	XPDelta     int    `json:"xp_delta"`
+	XPAfter     int64  `json:"xp_after"`
+	Level       int    `json:"level"`
 }
 
 type savedGameResult struct {
@@ -612,27 +622,33 @@ func (store *apiRoomSettingsStore) GetRoomSettings(roomID, token string) (roomSe
 	return settings, nil
 }
 
-func (store *apiGameHistoryStore) SaveGame(result savedGameResult) error {
+func (store *apiGameHistoryStore) SaveGame(result savedGameResult) ([]playerDelta, error) {
 	payload, err := json.Marshal(result)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	req, err := http.NewRequest(http.MethodPost, store.url, bytes.NewReader(payload))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	setInternalSecret(req, store.secret)
 	resp, err := store.client.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("save game returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return nil, fmt.Errorf("save game returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
-	return nil
+	var saveResp struct {
+		Deltas []playerDelta `json:"deltas"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&saveResp); err != nil {
+		return nil, nil
+	}
+	return saveResp.Deltas, nil
 }
 
 // setInternalSecret attaches the shared internal-API secret header when one is
@@ -2147,8 +2163,17 @@ func (room *room) saveGameResult() {
 	// practice round can't pollute the leaderboard. Status is still flipped to
 	// 'finished' so the room can be reconciled/cleaned up like any other.
 	if historyStore != nil && !practiceMode {
-		if err := historyStore.SaveGame(result); err != nil {
+		deltas, err := historyStore.SaveGame(result)
+		if err != nil {
 			log.Printf("save game result: %v", err)
+		} else if len(deltas) > 0 {
+			deltaMap := make(map[string]playerDelta, len(deltas))
+			for _, d := range deltas {
+				deltaMap[d.UserID] = d
+			}
+			room.mu.Lock()
+			room.gameDeltas = deltaMap
+			room.mu.Unlock()
 		}
 	}
 	if statusUpdater != nil {
@@ -2188,7 +2213,7 @@ func (room *room) results() []map[string]any {
 	results := make([]map[string]any, 0, len(scoredPlayers))
 	for _, scoredPlayer := range scoredPlayers {
 		player := scoredPlayer.player
-		results = append(results, map[string]any{
+		entry := map[string]any{
 			"display_name":   player.displayName,
 			"avatar_url":     player.avatar,
 			"is_bot":         player.isBot,
@@ -2196,7 +2221,17 @@ func (room *room) results() []map[string]any {
 			"penalty_points": scoredPlayer.score,
 			"rank":           scoredPlayer.rank,
 			"is_winner":      scoredPlayer.isWinner,
-		})
+		}
+		if !player.isBot && !player.isGuest {
+			if d, ok := room.gameDeltas[player.sub]; ok {
+				entry["rating_delta"] = d.RatingDelta
+				entry["rating_after"] = d.RatingAfter
+				entry["xp_delta"] = d.XPDelta
+				entry["xp_after"] = d.XPAfter
+				entry["level"] = d.Level
+			}
+		}
+		results = append(results, entry)
 	}
 	return results
 }

--- a/services/ws/server_test.go
+++ b/services/ws/server_test.go
@@ -17,9 +17,9 @@ type memoryGameHistoryStore struct {
 	results []savedGameResult
 }
 
-func (store *memoryGameHistoryStore) SaveGame(result savedGameResult) error {
+func (store *memoryGameHistoryStore) SaveGame(result savedGameResult) ([]playerDelta, error) {
 	store.results = append(store.results, result)
-	return nil
+	return nil, nil
 }
 
 type staticRoomSettingsStore struct {

--- a/web/src/hooks/useGameSocket.ts
+++ b/web/src/hooks/useGameSocket.ts
@@ -51,6 +51,11 @@ type GameOverMessage = {
     is_winner: boolean
     is_bot?: boolean
     facedown_cards?: Array<{ suit: string; rank: string | number; points: number }>
+    rating_delta?: number
+    rating_after?: number
+    xp_delta?: number
+    xp_after?: number
+    level?: number
   }>
 }
 
@@ -887,6 +892,11 @@ function toGameResult(result: GameOverMessage['results'][number]): GameResult {
       ...toCard(card),
       points: card.points,
     })),
+    ratingDelta: result.rating_delta,
+    ratingAfter: result.rating_after,
+    xpDelta: result.xp_delta,
+    xpAfter: result.xp_after,
+    level: result.level,
   }
 }
 

--- a/web/src/pages/GamePage.tsx
+++ b/web/src/pages/GamePage.tsx
@@ -477,6 +477,7 @@ function GameOverPanel({ roomId, game }: { roomId: string | undefined; game: Gam
             </div>
           </div>
           <ScoreTable scores={scores} winnerLabel={winnerLabel} />
+          <MatchStatsCard results={game.results} myDisplayName={game.myDisplayName} practiceMode={game.practiceMode} />
           <RevealedPenaltyCards results={game.results} />
         </div>
 
@@ -534,6 +535,35 @@ function GameOverPanel({ roomId, game }: { roomId: string | undefined; game: Gam
         </div>
       </div>
     </SectionPanel>
+  )
+}
+
+function MatchStatsCard({ results, myDisplayName, practiceMode }: { results: GameResult[]; myDisplayName: string | null; practiceMode: boolean }) {
+  if (practiceMode || !myDisplayName) return null
+  const myResult = results.find((r) => r.player === myDisplayName)
+  if (!myResult || myResult.xpDelta === undefined) return null
+
+  const ratingDelta = myResult.ratingDelta ?? 0
+  const ratingSign = ratingDelta >= 0 ? '+' : ''
+
+  return (
+    <div className="rounded-spade-lg border border-spade-cream/10 bg-[#2b302d] p-4">
+      <h3 className="text-lg font-medium">Your match rewards</h3>
+      <div className="mt-3 grid grid-cols-2 gap-3">
+        <div className="rounded-spade-md border border-spade-cream/10 bg-spade-bg/45 p-3">
+          <p className="font-mono text-xs uppercase text-spade-gray-3">XP gained</p>
+          <p className="mt-1 text-lg font-medium text-spade-gold-light">+{myResult.xpDelta}</p>
+          <p className="mt-0.5 font-mono text-xs text-spade-gray-2">Level {myResult.level}</p>
+        </div>
+        <div className="rounded-spade-md border border-spade-cream/10 bg-spade-bg/45 p-3">
+          <p className="font-mono text-xs uppercase text-spade-gray-3">Rating</p>
+          <p className={`mt-1 text-lg font-medium ${ratingDelta > 0 ? 'text-green-400' : ratingDelta < 0 ? 'text-red-400' : 'text-spade-cream'}`}>
+            {ratingSign}{ratingDelta}
+          </p>
+          <p className="mt-0.5 font-mono text-xs text-spade-gray-2">{myResult.ratingAfter ?? '—'}</p>
+        </div>
+      </div>
+    </div>
   )
 }
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -65,6 +65,11 @@ export type GameResult = {
   winner: boolean
   bot?: boolean
   faceDownCards: RevealedPenaltyCard[]
+  ratingDelta?: number
+  ratingAfter?: number
+  xpDelta?: number
+  xpAfter?: number
+  level?: number
 }
 
 export type ToastTone = 'success' | 'warn' | 'info' | 'error'


### PR DESCRIPTION
- API SaveGame now returns per-player rating/XP deltas
- WS service relays deltas in the game_over payload
- Web and mobile show 'Your match rewards' card on results screen
- Shows XP gained, current level, and rating change (colored)
- Hidden for guests, bots, and practice mode games