### PR TITLE
feat: display rating delta in game history

### DIFF
--- a/mobile/app/(app)/history.tsx
+++ b/mobile/app/(app)/history.tsx
@@ -103,13 +103,17 @@ export default function HistoryScreen() {
           <View className="flex-row border-b border-spade-cream/10 bg-spade-cream/5 px-3 py-2">
             <Text className="flex-1 font-mono text-[10px] uppercase text-spade-gray-3">Started</Text>
             <Text className="w-20 font-mono text-[10px] uppercase text-spade-gray-3">Result</Text>
-            <Text className="w-16 text-right font-mono text-[10px] uppercase text-spade-gray-3">Penalty</Text>
+            <Text className="w-14 text-right font-mono text-[10px] uppercase text-spade-gray-3">Penalty</Text>
+            <Text className="w-14 text-right font-mono text-[10px] uppercase text-spade-gray-3">Rating</Text>
           </View>
           {games.map((game) => (
             <View key={game.game_id} className="flex-row items-center border-t border-spade-cream/10 px-3 py-3">
               <Text className="flex-1 text-xs text-spade-gray-2">{formatDate(game.started_at)}</Text>
               <Text className="w-20 text-sm text-spade-cream">{game.is_winner ? 'Winner' : `Rank ${game.rank}`}</Text>
-              <Text className="w-16 text-right font-mono text-sm text-spade-gold-light">{game.penalty_points}</Text>
+              <Text className="w-14 text-right font-mono text-sm text-spade-gold-light">{game.penalty_points}</Text>
+              <Text className={`w-14 text-right font-mono text-sm ${game.rating_delta != null ? (game.rating_delta > 0 ? 'text-green-400' : game.rating_delta < 0 ? 'text-red-400' : 'text-spade-gray-2') : 'text-spade-gray-2'}`}>
+                {game.rating_delta != null ? `${game.rating_delta >= 0 ? '+' : ''}${game.rating_delta}` : '—'}
+              </Text>
             </View>
           ))}
           {!isLoading && games.length === 0 ? (

--- a/mobile/src/api/history.ts
+++ b/mobile/src/api/history.ts
@@ -8,6 +8,7 @@ export type HistoryGameDto = {
   penalty_points: number
   rank: number
   is_winner: boolean
+  rating_delta?: number | null
 }
 
 export type HistoryResponse = {

--- a/services/api/internal/repository/game.go
+++ b/services/api/internal/repository/game.go
@@ -35,6 +35,7 @@ type HistoryGame struct {
 	PenaltyPoints int    `json:"penalty_points"`
 	Rank          int    `json:"rank"`
 	IsWinner      bool   `json:"is_winner"`
+	RatingDelta   *int   `json:"rating_delta"`
 }
 
 type PlayerDelta struct {
@@ -379,9 +380,12 @@ func GetPlayerHistory(db *sql.DB, userID uuid.UUID, page int, perPage int) ([]Hi
 	}
 
 	rows, err := db.Query(`
-		SELECT g.id, g.room_id, g.room_name, g.started_at, g.finished_at, gp.penalty_points, gp.rank, gp.is_winner
+		SELECT g.id, g.room_id, g.room_name, g.started_at, g.finished_at,
+		       gp.penalty_points, gp.rank, gp.is_winner,
+		       pre.rating_delta
 		FROM game_players gp
 		JOIN games g ON g.id = gp.game_id
+		LEFT JOIN player_rating_events pre ON pre.game_id = g.id AND pre.user_id = gp.user_id
 		WHERE gp.user_id = $1
 		ORDER BY g.finished_at DESC
 		LIMIT $2 OFFSET $3
@@ -396,12 +400,17 @@ func GetPlayerHistory(db *sql.DB, userID uuid.UUID, page int, perPage int) ([]Hi
 		var game HistoryGame
 		var startedAt, finishedAt time.Time
 		var roomName sql.NullString
-		if err := rows.Scan(&game.GameID, &game.RoomID, &roomName, &startedAt, &finishedAt, &game.PenaltyPoints, &game.Rank, &game.IsWinner); err != nil {
+		var ratingDelta sql.NullInt32
+		if err := rows.Scan(&game.GameID, &game.RoomID, &roomName, &startedAt, &finishedAt, &game.PenaltyPoints, &game.Rank, &game.IsWinner, &ratingDelta); err != nil {
 			return nil, 0, fmt.Errorf("scan history: %w", err)
 		}
 		game.RoomName = roomName.String
 		game.StartedAt = startedAt.UTC().Format(time.RFC3339)
 		game.FinishedAt = finishedAt.UTC().Format(time.RFC3339)
+		if ratingDelta.Valid {
+			v := int(ratingDelta.Int32)
+			game.RatingDelta = &v
+		}
 		games = append(games, game)
 	}
 	if err := rows.Err(); err != nil {

--- a/web/src/api/history.ts
+++ b/web/src/api/history.ts
@@ -9,6 +9,7 @@ export type HistoryGameDto = {
   penalty_points: number
   rank: number
   is_winner: boolean
+  rating_delta?: number | null
 }
 
 export type HistoryResponse = {

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -101,6 +101,7 @@ export function HistoryPage() {
               <th className="px-2 py-2">Started</th>
               <th className="px-2 py-2">Result</th>
               <th className="px-2 py-2">Penalty</th>
+              <th className="px-2 py-2">Rating</th>
               <th className="px-4 py-2">Finished</th>
             </tr>
           </thead>
@@ -111,12 +112,15 @@ export function HistoryPage() {
                 <td className="px-2 py-3 text-spade-gray-2">{formatDate(game.started_at)}</td>
                 <td className="px-2 py-3">{game.is_winner ? 'Winner' : `Rank ${game.rank}`}</td>
                 <td className="px-2 py-3 font-mono text-spade-gold-light">{game.penalty_points}</td>
+                <td className={`px-2 py-3 font-mono ${game.rating_delta != null ? (game.rating_delta > 0 ? 'text-green-400' : game.rating_delta < 0 ? 'text-red-400' : 'text-spade-gray-2') : 'text-spade-gray-2'}`}>
+                  {game.rating_delta != null ? `${game.rating_delta >= 0 ? '+' : ''}${game.rating_delta}` : '—'}
+                </td>
                 <td className="px-4 py-3 text-xs text-spade-gray-2">{formatDate(game.finished_at)}</td>
               </tr>
             ))}
             {!isLoading && games.length === 0 ? (
               <tr className="border-t border-spade-cream/8">
-                <td colSpan={5} className="px-4 py-8 text-center text-sm text-spade-gray-2">
+                <td colSpan={6} className="px-4 py-8 text-center text-sm text-spade-gray-2">
                   No completed games yet.
                 </td>
               </tr>


### PR DESCRIPTION
- API GetPlayerHistory joins player_rating_events to include rating_delta
- Web history table adds Rating column with color-coded +/- values
- Mobile history list adds Rating column with same styling