### PR TITLE
feat: game replay / move history (#44)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -142,7 +142,7 @@ All backlog items are tracked as GitHub issues in the [Post-MVP Features](https:
 | 🔲 | Issue | Effort |
 |---|---|---|
 | ✅ | [#43](https://github.com/faytranevozter/7spade/issues/43) [Seasons & ELO Rating](./specs/seasons-and-elo.md) | High |
-| 🔲 | [#44](https://github.com/faytranevozter/7spade/issues/44) Game Replay / Move History | Medium-High |
+| ✅ | [#44](https://github.com/faytranevozter/7spade/issues/44) Game Replay / Move History | Medium-High |
 | 🔲 | [#45](https://github.com/faytranevozter/7spade/issues/45) Party / Group Queue | Medium |
 | ✅ | [#46](https://github.com/faytranevozter/7spade/issues/46) Profile Stat Comparison (You vs Player) | Low |
 | ✅ | [#47](https://github.com/faytranevozter/7spade/issues/47) [Spectator Emotes](./specs/emotes.md#7a-spectator-emotes-issue-47) — chat deferred | Low |

--- a/services/api/internal/database/migrations/024_game_replays.sql
+++ b/services/api/internal/database/migrations/024_game_replays.sql
@@ -1,0 +1,29 @@
+-- Game replay: per-move log and initial dealt hands for the last 20 games.
+-- Older replay data is pruned on each save so storage stays bounded.
+
+-- ============================================================================
+-- game_moves — ordered log of every card played in a game
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS game_moves (
+    game_id            UUID         NOT NULL REFERENCES games(id) ON DELETE CASCADE,
+    move_index         INT          NOT NULL,
+    player_index       SMALLINT     NOT NULL,
+    card_rank          SMALLINT,
+    card_suit          SMALLINT,
+    move_type          VARCHAR(16)  NOT NULL,
+    ace_close_direction VARCHAR(4),
+    created_at         TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (game_id, move_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_game_moves_game ON game_moves(game_id, move_index);
+
+-- ============================================================================
+-- game_initial_hands — the dealt hand for each seat at game start
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS game_initial_hands (
+    game_id      UUID     NOT NULL REFERENCES games(id) ON DELETE CASCADE,
+    player_index SMALLINT NOT NULL,
+    hand         JSONB    NOT NULL,
+    PRIMARY KEY (game_id, player_index)
+);

--- a/services/api/internal/handler/history.go
+++ b/services/api/internal/handler/history.go
@@ -54,6 +54,28 @@ func (h HistoryHandler) Save(c *gin.Context) {
 	c.JSON(http.StatusCreated, gin.H{"game_id": saveResult.GameID.String(), "deltas": saveResult.Deltas})
 }
 
+// Replay returns the full move list + initial deal for a finished game. Any
+// authenticated user may read it (replays are shareable). Returns 404 when no
+// replay data exists (the game is older than the retention window).
+func (h HistoryHandler) Replay(c *gin.Context) {
+	gameID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		JSONError(c, http.StatusBadRequest, "Invalid game id")
+		return
+	}
+	replay, ok, err := repository.GetReplay(h.DB, gameID)
+	if err != nil {
+		log.Printf("history: get replay: %v", err)
+		JSONError(c, http.StatusInternalServerError, "Failed to load replay")
+		return
+	}
+	if !ok {
+		JSONError(c, http.StatusNotFound, "Replay not available")
+		return
+	}
+	c.JSON(http.StatusOK, replay)
+}
+
 func positiveQueryInt(c *gin.Context, key string, fallback int) int {
 	value, err := strconv.Atoi(c.Query(key))
 	if err != nil || value < 1 {

--- a/services/api/internal/repository/game.go
+++ b/services/api/internal/repository/game.go
@@ -11,11 +11,57 @@ import (
 )
 
 type GameResult struct {
-	RoomID     string             `json:"room_id"`
-	StartedAt  time.Time          `json:"started_at"`
-	FinishedAt time.Time          `json:"finished_at"`
-	Players    []GameResultPlayer `json:"players"`
+	RoomID       string             `json:"room_id"`
+	StartedAt    time.Time          `json:"started_at"`
+	FinishedAt   time.Time          `json:"finished_at"`
+	Players      []GameResultPlayer `json:"players"`
+	InitialHands [][]ReplayCard     `json:"initial_hands,omitempty"`
+	Moves        []ReplayMove       `json:"moves,omitempty"`
 }
+
+// ReplayCard is a single card in a replay payload. Suit is the engine string
+// (spades/hearts/diamonds/clubs); Rank is the engine int (2..14, Ace=14).
+type ReplayCard struct {
+	Suit string `json:"suit"`
+	Rank int    `json:"rank"`
+}
+
+// ReplayMove is a single recorded move. Type is one of "play", "face_down", or
+// "ace_close"; AceDirection ("low"/"high") is set only for ace_close moves.
+type ReplayMove struct {
+	Index        int    `json:"index"`
+	PlayerIndex  int    `json:"player_index"`
+	Suit         string `json:"suit"`
+	Rank         int    `json:"rank"`
+	Type         string `json:"type"`
+	AceDirection string `json:"ace_direction,omitempty"`
+}
+
+// Replay is the full replay payload returned by GetReplay: game metadata, the
+// initial dealt hands per seat, and the ordered move sequence.
+type Replay struct {
+	GameID       string         `json:"game_id"`
+	RoomName     string         `json:"room_name"`
+	StartedAt    string         `json:"started_at"`
+	FinishedAt   string         `json:"finished_at"`
+	Players      []ReplayPlayer `json:"players"`
+	InitialHands [][]ReplayCard `json:"initial_hands"`
+	Moves        []ReplayMove   `json:"moves"`
+}
+
+// ReplayPlayer labels a seat in the replay (index 0..3).
+type ReplayPlayer struct {
+	PlayerIndex int    `json:"player_index"`
+	DisplayName string `json:"display_name"`
+	IsBot       bool   `json:"is_bot"`
+	IsWinner    bool   `json:"is_winner"`
+	Rank        int    `json:"rank"`
+}
+
+// replayRetention is the number of most-recent games (by finished_at) whose
+// replay data is kept. Older games' moves and initial hands are pruned on each
+// save so storage stays bounded.
+const replayRetention = 20
 
 type GameResultPlayer struct {
 	UserID        string `json:"user_id,omitempty"`
@@ -27,15 +73,16 @@ type GameResultPlayer struct {
 }
 
 type HistoryGame struct {
-	GameID        string `json:"game_id"`
-	RoomID        string `json:"room_id"`
-	RoomName      string `json:"room_name"`
-	StartedAt     string `json:"started_at"`
-	FinishedAt    string `json:"finished_at"`
-	PenaltyPoints int    `json:"penalty_points"`
-	Rank          int    `json:"rank"`
-	IsWinner      bool   `json:"is_winner"`
-	RatingDelta   *int   `json:"rating_delta"`
+	GameID          string `json:"game_id"`
+	RoomID          string `json:"room_id"`
+	RoomName        string `json:"room_name"`
+	StartedAt       string `json:"started_at"`
+	FinishedAt      string `json:"finished_at"`
+	PenaltyPoints   int    `json:"penalty_points"`
+	Rank            int    `json:"rank"`
+	IsWinner        bool   `json:"is_winner"`
+	RatingDelta     *int   `json:"rating_delta"`
+	ReplayAvailable bool   `json:"replay_available"`
 }
 
 type PlayerDelta struct {
@@ -249,6 +296,13 @@ func SaveGame(db *sql.DB, result GameResult) (GameSaveResult, error) {
 		}
 	}
 
+	if err := insertReplay(tx, gameID, result.InitialHands, result.Moves); err != nil {
+		return empty, err
+	}
+	if err := pruneOldReplays(tx); err != nil {
+		return empty, err
+	}
+
 	if err := tx.Commit(); err != nil {
 		return empty, fmt.Errorf("commit save game: %w", err)
 	}
@@ -382,7 +436,8 @@ func GetPlayerHistory(db *sql.DB, userID uuid.UUID, page int, perPage int) ([]Hi
 	rows, err := db.Query(`
 		SELECT g.id, g.room_id, g.room_name, g.started_at, g.finished_at,
 		       gp.penalty_points, gp.rank, gp.is_winner,
-		       pre.rating_delta
+		       pre.rating_delta,
+		       EXISTS(SELECT 1 FROM game_initial_hands h WHERE h.game_id = g.id) AS replay_available
 		FROM game_players gp
 		JOIN games g ON g.id = gp.game_id
 		LEFT JOIN player_rating_events pre ON pre.game_id = g.id AND pre.user_id = gp.user_id
@@ -401,7 +456,7 @@ func GetPlayerHistory(db *sql.DB, userID uuid.UUID, page int, perPage int) ([]Hi
 		var startedAt, finishedAt time.Time
 		var roomName sql.NullString
 		var ratingDelta sql.NullInt32
-		if err := rows.Scan(&game.GameID, &game.RoomID, &roomName, &startedAt, &finishedAt, &game.PenaltyPoints, &game.Rank, &game.IsWinner, &ratingDelta); err != nil {
+		if err := rows.Scan(&game.GameID, &game.RoomID, &roomName, &startedAt, &finishedAt, &game.PenaltyPoints, &game.Rank, &game.IsWinner, &ratingDelta, &game.ReplayAvailable); err != nil {
 			return nil, 0, fmt.Errorf("scan history: %w", err)
 		}
 		game.RoomName = roomName.String
@@ -459,4 +514,179 @@ func GetRatingHistory(db *sql.DB, userID uuid.UUID, page, perPage int) ([]Rating
 		return nil, 0, fmt.Errorf("iterate rating events: %w", err)
 	}
 	return events, total, nil
+}
+
+// insertReplay persists the initial dealt hands and the ordered move log for a
+// game inside the save transaction. A game with no moves (e.g. practice mode is
+// not saved at all, but defensively) writes nothing.
+func insertReplay(tx *sql.Tx, gameID uuid.UUID, initialHands [][]ReplayCard, moves []ReplayMove) error {
+	if len(moves) == 0 {
+		return nil
+	}
+	for seat, hand := range initialHands {
+		payload, err := json.Marshal(hand)
+		if err != nil {
+			return fmt.Errorf("marshal initial hand: %w", err)
+		}
+		if _, err := tx.Exec(`
+			INSERT INTO game_initial_hands (game_id, player_index, hand)
+			VALUES ($1, $2, $3)
+			ON CONFLICT (game_id, player_index) DO NOTHING
+		`, gameID, seat, payload); err != nil {
+			return fmt.Errorf("insert initial hand: %w", err)
+		}
+	}
+	for i, m := range moves {
+		idx := m.Index
+		if idx == 0 && i != 0 {
+			idx = i
+		}
+		var aceDir interface{}
+		if m.AceDirection != "" {
+			aceDir = m.AceDirection
+		}
+		if _, err := tx.Exec(`
+			INSERT INTO game_moves (game_id, move_index, player_index, card_rank, card_suit, move_type, ace_close_direction)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)
+			ON CONFLICT (game_id, move_index) DO NOTHING
+		`, gameID, idx, m.PlayerIndex, m.Rank, suitToCode(m.Suit), m.Type, aceDir); err != nil {
+			return fmt.Errorf("insert move: %w", err)
+		}
+	}
+	return nil
+}
+
+// pruneOldReplays deletes replay data (moves + initial hands) for games outside
+// the most-recent replayRetention window, keeping storage bounded.
+func pruneOldReplays(tx *sql.Tx) error {
+	const keep = `
+		SELECT id FROM games ORDER BY finished_at DESC LIMIT $1
+	`
+	if _, err := tx.Exec(`DELETE FROM game_moves WHERE game_id NOT IN (`+keep+`)`, replayRetention); err != nil {
+		return fmt.Errorf("prune game moves: %w", err)
+	}
+	if _, err := tx.Exec(`DELETE FROM game_initial_hands WHERE game_id NOT IN (`+keep+`)`, replayRetention); err != nil {
+		return fmt.Errorf("prune initial hands: %w", err)
+	}
+	return nil
+}
+
+// suit codes map the engine suit string to the SMALLINT stored in game_moves.
+var suitCodes = map[string]int{"spades": 0, "hearts": 1, "diamonds": 2, "clubs": 3}
+var suitNames = map[int]string{0: "spades", 1: "hearts", 2: "diamonds", 3: "clubs"}
+
+func suitToCode(suit string) int {
+	if code, ok := suitCodes[suit]; ok {
+		return code
+	}
+	return 0
+}
+
+func suitFromCode(code int) string {
+	if name, ok := suitNames[code]; ok {
+		return name
+	}
+	return "spades"
+}
+
+// GetReplay returns the full replay for a game: metadata, the initial dealt
+// hands per seat, and the ordered move sequence. ok=false when no replay data
+// exists (the game is older than the retention window, or never recorded).
+func GetReplay(db *sql.DB, gameID uuid.UUID) (Replay, bool, error) {
+	var replay Replay
+	var roomName sql.NullString
+	var startedAt, finishedAt time.Time
+	err := db.QueryRow(`
+		SELECT id, room_name, started_at, finished_at FROM games WHERE id = $1
+	`, gameID).Scan(&replay.GameID, &roomName, &startedAt, &finishedAt)
+	if err == sql.ErrNoRows {
+		return Replay{}, false, nil
+	}
+	if err != nil {
+		return Replay{}, false, fmt.Errorf("query game: %w", err)
+	}
+	replay.RoomName = roomName.String
+	replay.StartedAt = startedAt.UTC().Format(time.RFC3339)
+	replay.FinishedAt = finishedAt.UTC().Format(time.RFC3339)
+
+	playerRows, err := db.Query(`
+		SELECT display_name, is_bot, is_winner, rank
+		FROM game_players WHERE game_id = $1 ORDER BY rank ASC
+	`, gameID)
+	if err != nil {
+		return Replay{}, false, fmt.Errorf("query replay players: %w", err)
+	}
+	defer playerRows.Close()
+	seat := 0
+	for playerRows.Next() {
+		var p ReplayPlayer
+		if err := playerRows.Scan(&p.DisplayName, &p.IsBot, &p.IsWinner, &p.Rank); err != nil {
+			return Replay{}, false, fmt.Errorf("scan replay player: %w", err)
+		}
+		p.PlayerIndex = seat
+		seat++
+		replay.Players = append(replay.Players, p)
+	}
+	if err := playerRows.Err(); err != nil {
+		return Replay{}, false, fmt.Errorf("iterate replay players: %w", err)
+	}
+
+	handRows, err := db.Query(`
+		SELECT player_index, hand FROM game_initial_hands
+		WHERE game_id = $1 ORDER BY player_index ASC
+	`, gameID)
+	if err != nil {
+		return Replay{}, false, fmt.Errorf("query initial hands: %w", err)
+	}
+	defer handRows.Close()
+	hands := [][]ReplayCard{}
+	hasReplay := false
+	for handRows.Next() {
+		var idx int
+		var payload []byte
+		if err := handRows.Scan(&idx, &payload); err != nil {
+			return Replay{}, false, fmt.Errorf("scan initial hand: %w", err)
+		}
+		var hand []ReplayCard
+		if err := json.Unmarshal(payload, &hand); err != nil {
+			return Replay{}, false, fmt.Errorf("unmarshal initial hand: %w", err)
+		}
+		hands = append(hands, hand)
+		hasReplay = true
+	}
+	if err := handRows.Err(); err != nil {
+		return Replay{}, false, fmt.Errorf("iterate initial hands: %w", err)
+	}
+	if !hasReplay {
+		return Replay{}, false, nil
+	}
+	replay.InitialHands = hands
+
+	moveRows, err := db.Query(`
+		SELECT move_index, player_index, card_rank, card_suit, move_type, ace_close_direction
+		FROM game_moves WHERE game_id = $1 ORDER BY move_index ASC
+	`, gameID)
+	if err != nil {
+		return Replay{}, false, fmt.Errorf("query moves: %w", err)
+	}
+	defer moveRows.Close()
+	moves := []ReplayMove{}
+	for moveRows.Next() {
+		var m ReplayMove
+		var rank, suit sql.NullInt32
+		var aceDir sql.NullString
+		if err := moveRows.Scan(&m.Index, &m.PlayerIndex, &rank, &suit, &m.Type, &aceDir); err != nil {
+			return Replay{}, false, fmt.Errorf("scan move: %w", err)
+		}
+		m.Rank = int(rank.Int32)
+		m.Suit = suitFromCode(int(suit.Int32))
+		m.AceDirection = aceDir.String
+		moves = append(moves, m)
+	}
+	if err := moveRows.Err(); err != nil {
+		return Replay{}, false, fmt.Errorf("iterate moves: %w", err)
+	}
+	replay.Moves = moves
+
+	return replay, true, nil
 }

--- a/services/api/internal/repository/game_test.go
+++ b/services/api/internal/repository/game_test.go
@@ -55,6 +55,10 @@ func TestSaveGameUpdatesRegisteredPlayerStats(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"rating"}).AddRow(1200))
 	mock.ExpectExec("INSERT INTO player_rating_events").
 		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM game_moves").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM game_initial_hands").
+		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	if _, err := SaveGame(db, result); err != nil {

--- a/services/api/internal/server/router.go
+++ b/services/api/internal/server/router.go
@@ -80,6 +80,7 @@ func NewRouter(cfg *config.Config, db *sql.DB, rdb *cache.RedisClient) *gin.Engi
 	authed.POST("/rooms/:code/join", roomHandler.Join)
 	authed.GET("/my/active-room", roomHandler.MyActiveRoom)
 	authed.GET("/history", historyHandler.List)
+	authed.GET("/games/:id/replay", historyHandler.Replay)
 	authed.GET("/stats", statsHandler.Me)
 	authed.GET("/me", authHandler.Me)
 	authed.PATCH("/me", authHandler.UpdateMe)

--- a/services/ws/lobby.go
+++ b/services/ws/lobby.go
@@ -390,6 +390,7 @@ func (room *room) handleKick(initiator *player, targetSlot int) {
 	// the kick server-side so the player can't rejoin via the HTTP join path.
 	room.removeAndNotifyLobbyLeaveLocked(target, true)
 }
+
 // the membership row. Caller must hold room.mu; this function releases it.
 func (room *room) removeAndNotifyLobbyLeaveLocked(target *player, kick bool) {
 	room.removeLobbyPlayerLocked(target)
@@ -570,6 +571,11 @@ func (room *room) handleStartGame(initiator *player) {
 	state, starter := game.Deal(time.Now().UnixNano())
 	room.state = state
 	room.state.CurrentPlayer = starter
+	for i := range room.state.Hands {
+		room.initialHands[i] = append([]game.Card(nil), room.state.Hands[i]...)
+	}
+	room.moves = nil
+	room.savedGameID = ""
 	room.phase = phasePlaying
 	room.started = true
 	room.startedAt = time.Now().UTC()
@@ -649,13 +655,14 @@ func (room *room) executeBotMove(botIdx int) {
 		room.mu.Unlock()
 		return
 	}
-	state, err := applyBotMove(room.state, botIdx, move)
+	state, rec, err := applyBotMove(room.state, botIdx, move)
 	if err != nil {
 		log.Printf("bot move failed: %v", err)
 		room.mu.Unlock()
 		return
 	}
 	room.state = state
+	room.moves = append(room.moves, rec)
 	room.persistLocked()
 	gameOver := game.IsGameOver(room.state)
 	if !gameOver {

--- a/services/ws/server.go
+++ b/services/ws/server.go
@@ -122,7 +122,16 @@ type room struct {
 	kickedSubs        map[string]bool
 	spectators        []*spectator
 	gameDeltas        map[string]playerDelta
-	mu                sync.Mutex
+	savedGameID       string
+
+	// Replay recording: the hands dealt at the start of the current game and
+	// the ordered log of moves applied since the deal. Reset on every deal and
+	// persisted in the room snapshot so an in-progress replay survives a WS
+	// restart. Shipped to the API on game over.
+	initialHands [game.PlayerCount][]game.Card
+	moves        []recordedMove
+
+	mu sync.Mutex
 
 	// roomRelay is set when the server is running with cross-replica relay
 	// enabled. nil means single-process mode, in which every send writes
@@ -187,6 +196,8 @@ type roomSnapshot struct {
 	practiceMode     bool
 	turnTimerToken   int
 	rematchVotes     []int
+	initialHands     [game.PlayerCount][]game.Card
+	moves            []recordedMove
 }
 
 // roomSettingsStore supplies persisted room configuration from the API. The WS
@@ -215,7 +226,7 @@ func normalizeBotDifficulty(value string) game.BotDifficulty {
 }
 
 type gameHistoryStore interface {
-	SaveGame(result savedGameResult) ([]playerDelta, error)
+	SaveGame(result savedGameResult) (string, []playerDelta, error)
 }
 
 type playerDelta struct {
@@ -228,10 +239,12 @@ type playerDelta struct {
 }
 
 type savedGameResult struct {
-	RoomID     string            `json:"room_id"`
-	StartedAt  time.Time         `json:"started_at"`
-	FinishedAt time.Time         `json:"finished_at"`
-	Players    []savedGamePlayer `json:"players"`
+	RoomID       string            `json:"room_id"`
+	StartedAt    time.Time         `json:"started_at"`
+	FinishedAt   time.Time         `json:"finished_at"`
+	Players      []savedGamePlayer `json:"players"`
+	InitialHands [][]savedCard     `json:"initial_hands,omitempty"`
+	Moves        []savedReplayMove `json:"moves,omitempty"`
 }
 
 type savedGamePlayer struct {
@@ -241,6 +254,66 @@ type savedGamePlayer struct {
 	Rank          int    `json:"rank"`
 	IsWinner      bool   `json:"is_winner"`
 	IsBot         bool   `json:"is_bot"`
+}
+
+// recordedMove captures a single applied move for replay. PlayerIndex is the
+// seat 0..3, Suit/Rank identify the card, Type is one of "play", "face_down",
+// or "ace_close", and AceDirection is "low" or "high" only for ace_close moves.
+type recordedMove struct {
+	PlayerIndex  int
+	Suit         game.Suit
+	Rank         game.Rank
+	Type         string
+	AceDirection game.CloseMethod
+}
+
+// Move type constants used by the replay system to describe how a card was
+// played. Match the values stored in the API's game_moves.move_type column.
+const (
+	moveTypePlay     = "play"
+	moveTypeFaceDown = "face_down"
+	moveTypeAceClose = "ace_close"
+)
+
+// savedCard is the wire form of a card used in replay payloads. Suit is the
+// engine string (spades/hearts/diamonds/clubs); Rank is the engine int (2..14).
+type savedCard struct {
+	Suit string `json:"suit"`
+	Rank int    `json:"rank"`
+}
+
+func toSavedCards(cards []game.Card) []savedCard {
+	out := make([]savedCard, len(cards))
+	for i, c := range cards {
+		out[i] = savedCard{Suit: string(c.Suit), Rank: int(c.Rank)}
+	}
+	return out
+}
+
+// savedReplayMove is the wire form of a recorded move. Index is its 0-based
+// position in the game's move sequence.
+type savedReplayMove struct {
+	Index        int    `json:"index"`
+	PlayerIndex  int    `json:"player_index"`
+	Suit         string `json:"suit"`
+	Rank         int    `json:"rank"`
+	Type         string `json:"type"`
+	AceDirection string `json:"ace_direction,omitempty"`
+}
+
+func toSavedMoves(moves []recordedMove) []savedReplayMove {
+	out := make([]savedReplayMove, len(moves))
+	for i, m := range moves {
+		out[i] = savedReplayMove{
+			Index:        i,
+			PlayerIndex:  m.PlayerIndex,
+			Suit:         string(m.Suit),
+			Rank:         int(m.Rank),
+			Type:         m.Type,
+			AceDirection: string(m.AceDirection),
+		}
+	}
+	return out
 }
 
 type apiGameHistoryStore struct {
@@ -622,33 +695,34 @@ func (store *apiRoomSettingsStore) GetRoomSettings(roomID, token string) (roomSe
 	return settings, nil
 }
 
-func (store *apiGameHistoryStore) SaveGame(result savedGameResult) ([]playerDelta, error) {
+func (store *apiGameHistoryStore) SaveGame(result savedGameResult) (string, []playerDelta, error) {
 	payload, err := json.Marshal(result)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 	req, err := http.NewRequest(http.MethodPost, store.url, bytes.NewReader(payload))
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	setInternalSecret(req, store.secret)
 	resp, err := store.client.Do(req)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("save game returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return "", nil, fmt.Errorf("save game returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	var saveResp struct {
+		GameID string        `json:"game_id"`
 		Deltas []playerDelta `json:"deltas"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&saveResp); err != nil {
-		return nil, nil
+		return "", nil, nil
 	}
-	return saveResp.Deltas, nil
+	return saveResp.GameID, saveResp.Deltas, nil
 }
 
 // setInternalSecret attaches the shared internal-API secret header when one is
@@ -760,6 +834,25 @@ func toStoreSnapshot(snap roomSnapshot) store.RoomSnapshot {
 			Index:       p.index,
 		})
 	}
+	var initialHands [game.PlayerCount][]game.Card
+	for i := range snap.initialHands {
+		if len(snap.initialHands[i]) > 0 {
+			initialHands[i] = append([]game.Card(nil), snap.initialHands[i]...)
+		}
+	}
+	var moves []store.PersistedMove
+	if len(snap.moves) > 0 {
+		moves = make([]store.PersistedMove, len(snap.moves))
+		for i, m := range snap.moves {
+			moves[i] = store.PersistedMove{
+				PlayerIndex:  m.PlayerIndex,
+				Suit:         string(m.Suit),
+				Rank:         int(m.Rank),
+				Type:         m.Type,
+				AceDirection: string(m.AceDirection),
+			}
+		}
+	}
 	return store.RoomSnapshot{
 		State:            snap.state,
 		Players:          players,
@@ -772,6 +865,8 @@ func toStoreSnapshot(snap roomSnapshot) store.RoomSnapshot {
 		PracticeMode:     snap.practiceMode,
 		TurnTimerToken:   snap.turnTimerToken,
 		RematchVotes:     append([]int(nil), snap.rematchVotes...),
+		InitialHands:     initialHands,
+		Moves:            moves,
 	}
 }
 
@@ -788,6 +883,25 @@ func fromStoreSnapshot(snap store.RoomSnapshot) roomSnapshot {
 			index:       p.Index,
 		})
 	}
+	var initialHands [game.PlayerCount][]game.Card
+	for i := range snap.InitialHands {
+		if len(snap.InitialHands[i]) > 0 {
+			initialHands[i] = append([]game.Card(nil), snap.InitialHands[i]...)
+		}
+	}
+	var moves []recordedMove
+	if len(snap.Moves) > 0 {
+		moves = make([]recordedMove, len(snap.Moves))
+		for i, m := range snap.Moves {
+			moves[i] = recordedMove{
+				PlayerIndex:  m.PlayerIndex,
+				Suit:         game.Suit(m.Suit),
+				Rank:         game.Rank(m.Rank),
+				Type:         m.Type,
+				AceDirection: game.CloseMethod(m.AceDirection),
+			}
+		}
+	}
 	return roomSnapshot{
 		state:            snap.State,
 		players:          players,
@@ -800,6 +914,8 @@ func fromStoreSnapshot(snap store.RoomSnapshot) roomSnapshot {
 		practiceMode:     snap.PracticeMode,
 		turnTimerToken:   snap.TurnTimerToken,
 		rematchVotes:     append([]int(nil), snap.RematchVotes...),
+		initialHands:     initialHands,
+		moves:            moves,
 	}
 }
 
@@ -841,6 +957,12 @@ func (room *room) snapshotLocked() roomSnapshot {
 	for idx := range room.rematchVotes {
 		votes = append(votes, idx)
 	}
+	var initialHands [game.PlayerCount][]game.Card
+	for i := range room.initialHands {
+		if len(room.initialHands[i]) > 0 {
+			initialHands[i] = append([]game.Card(nil), room.initialHands[i]...)
+		}
+	}
 	return roomSnapshot{
 		state:            cloneGameState(room.state),
 		players:          players,
@@ -853,6 +975,8 @@ func (room *room) snapshotLocked() roomSnapshot {
 		practiceMode:     room.practiceMode,
 		turnTimerToken:   room.turnTimerToken,
 		rematchVotes:     votes,
+		initialHands:     initialHands,
+		moves:            append([]recordedMove(nil), room.moves...),
 	}
 }
 
@@ -891,6 +1015,14 @@ func (room *room) restoreFromSnapshotLocked(snap roomSnapshot) {
 	for _, idx := range snap.rematchVotes {
 		room.rematchVotes[idx] = true
 	}
+	for i := range snap.initialHands {
+		if len(snap.initialHands[i]) > 0 {
+			room.initialHands[i] = append([]game.Card(nil), snap.initialHands[i]...)
+		} else {
+			room.initialHands[i] = nil
+		}
+	}
+	room.moves = append([]recordedMove(nil), snap.moves...)
 	room.players = make([]*player, 0, len(snap.players))
 	for _, p := range snap.players {
 		room.players = append(room.players, &player{
@@ -901,11 +1033,9 @@ func (room *room) restoreFromSnapshotLocked(snap roomSnapshot) {
 			isBot:        p.isBot,
 			ready:        p.ready,
 			index:        p.index,
-			disconnected: !p.isBot, // humans have no socket yet; bots are always "present"
+			disconnected: !p.isBot,
 		})
 	}
-	// Resume the turn timer for an in-progress game so play continues even if no
-	// human reconnects (auto-play keeps bots and absent players moving).
 	if room.phase == phasePlaying && room.started && !game.IsGameOver(room.state) {
 		room.startTurnTimerLocked()
 	}
@@ -1421,13 +1551,14 @@ func (room *room) handleMessage(player *player, message clientMessage) {
 		return
 	}
 
-	state, err := applyClientMessage(room.state, player.index, message)
+	state, move, err := applyClientMessage(room.state, player.index, message)
 	if err != nil {
 		room.mu.Unlock()
 		player.sendError(err.Error())
 		return
 	}
 	room.state = state
+	room.moves = append(room.moves, move)
 	room.persistLocked()
 	gameOver := game.IsGameOver(room.state)
 	if !gameOver {
@@ -1491,6 +1622,11 @@ func (room *room) startRematchGameLocked() {
 	state, starter := game.Deal(time.Now().UnixNano())
 	room.state = state
 	room.state.CurrentPlayer = starter
+	for i := range room.state.Hands {
+		room.initialHands[i] = append([]game.Card(nil), room.state.Hands[i]...)
+	}
+	room.moves = nil
+	room.savedGameID = ""
 	room.rematchVotes = map[int]bool{}
 	room.startedAt = time.Now().UTC()
 	room.persistLocked()
@@ -1727,18 +1863,19 @@ func (room *room) handleTurnTimerExpired(token int) {
 		return
 	}
 	playerIndex := room.state.CurrentPlayer
-	move, ok := game.PickMoveWithDifficulty(room.state, playerIndex, room.botDifficulty)
+	botMove, ok := game.PickMoveWithDifficulty(room.state, playerIndex, room.botDifficulty)
 	if !ok {
 		room.mu.Unlock()
 		return
 	}
-	state, err := applyBotMove(room.state, playerIndex, move)
+	state, rec, err := applyBotMove(room.state, playerIndex, botMove)
 	if err != nil {
 		log.Printf("auto-play move failed: %v", err)
 		room.mu.Unlock()
 		return
 	}
 	room.state = state
+	room.moves = append(room.moves, rec)
 	room.persistLocked()
 	gameOver := game.IsGameOver(room.state)
 	if !gameOver {
@@ -1755,42 +1892,88 @@ func (room *room) handleTurnTimerExpired(token int) {
 	room.playBotIfNeeded()
 }
 
-func applyClientMessage(state game.GameState, playerIndex int, message clientMessage) (game.GameState, error) {
+func applyClientMessage(state game.GameState, playerIndex int, message clientMessage) (game.GameState, recordedMove, error) {
 	switch message.Type {
 	case messageTypePlayCard:
 		card, err := parseCard(message.Suit, message.Rank)
 		if err != nil {
-			return game.GameState{}, err
+			return game.GameState{}, recordedMove{}, err
 		}
-		// Aces never extend a sequence; a play_card on an Ace always means
-		// "close this suit". Resolve which end to close from the explicit
-		// method, the locked global method, or the single available end.
 		if card.Rank == game.Ace {
 			method, err := resolveAceCloseMethod(state, playerIndex, card.Suit, message.Method)
 			if err != nil {
-				return game.GameState{}, err
+				return game.GameState{}, recordedMove{}, err
 			}
-			return game.ApplyAceClose(state, playerIndex, card.Suit, method)
+			newState, err := game.ApplyAceClose(state, playerIndex, card.Suit, method)
+			if err != nil {
+				return game.GameState{}, recordedMove{}, err
+			}
+			return newState, recordedMove{
+				PlayerIndex:  playerIndex,
+				Suit:         card.Suit,
+				Rank:         card.Rank,
+				Type:         moveTypeAceClose,
+				AceDirection: method,
+			}, nil
 		}
-		return game.ApplyMove(state, playerIndex, card, false)
+		newState, err := game.ApplyMove(state, playerIndex, card, false)
+		if err != nil {
+			return game.GameState{}, recordedMove{}, err
+		}
+		return newState, recordedMove{
+			PlayerIndex: playerIndex,
+			Suit:        card.Suit,
+			Rank:        card.Rank,
+			Type:        moveTypePlay,
+		}, nil
 	case messageTypePlaceFaceDown:
 		card, err := parseCard(message.Suit, message.Rank)
 		if err != nil {
-			return game.GameState{}, err
+			return game.GameState{}, recordedMove{}, err
 		}
-		return game.ApplyMove(state, playerIndex, card, true)
+		newState, err := game.ApplyMove(state, playerIndex, card, true)
+		if err != nil {
+			return game.GameState{}, recordedMove{}, err
+		}
+		return newState, recordedMove{
+			PlayerIndex: playerIndex,
+			Suit:        card.Suit,
+			Rank:        card.Rank,
+			Type:        moveTypeFaceDown,
+		}, nil
 	default:
-		return game.GameState{}, fmt.Errorf("unknown message type: %s", message.Type)
+		return game.GameState{}, recordedMove{}, fmt.Errorf("unknown message type: %s", message.Type)
 	}
 }
 
-// applyBotMove applies a bot/auto-play move, routing Ace closes through
-// ApplyAceClose and everything else through ApplyMove.
-func applyBotMove(state game.GameState, playerIndex int, move game.BotMove) (game.GameState, error) {
+func applyBotMove(state game.GameState, playerIndex int, move game.BotMove) (game.GameState, recordedMove, error) {
 	if move.Close {
-		return game.ApplyAceClose(state, playerIndex, move.Card.Suit, move.Method)
+		newState, err := game.ApplyAceClose(state, playerIndex, move.Card.Suit, move.Method)
+		if err != nil {
+			return game.GameState{}, recordedMove{}, err
+		}
+		return newState, recordedMove{
+			PlayerIndex:  playerIndex,
+			Suit:         move.Card.Suit,
+			Rank:         move.Card.Rank,
+			Type:         moveTypeAceClose,
+			AceDirection: move.Method,
+		}, nil
 	}
-	return game.ApplyMove(state, playerIndex, move.Card, move.FaceDown)
+	moveType := moveTypePlay
+	if move.FaceDown {
+		moveType = moveTypeFaceDown
+	}
+	newState, err := game.ApplyMove(state, playerIndex, move.Card, move.FaceDown)
+	if err != nil {
+		return game.GameState{}, recordedMove{}, err
+	}
+	return newState, recordedMove{
+		PlayerIndex: playerIndex,
+		Suit:        move.Card.Suit,
+		Rank:        move.Card.Rank,
+		Type:        moveType,
+	}, nil
 }
 
 // resolveAceCloseMethod decides which end an Ace close targets. An explicit
@@ -2067,6 +2250,7 @@ func (room *room) gameOverMessageLocked() map[string]any {
 		"ace_close_method": room.state.CloseMethod,
 		"practice_mode":    room.practiceMode,
 		"spectator_count":  len(room.spectators),
+		"game_id":          room.savedGameID,
 	}
 }
 func (room *room) broadcastRematchStatus() {
@@ -2163,16 +2347,19 @@ func (room *room) saveGameResult() {
 	// practice round can't pollute the leaderboard. Status is still flipped to
 	// 'finished' so the room can be reconciled/cleaned up like any other.
 	if historyStore != nil && !practiceMode {
-		deltas, err := historyStore.SaveGame(result)
+		gameID, deltas, err := historyStore.SaveGame(result)
 		if err != nil {
 			log.Printf("save game result: %v", err)
-		} else if len(deltas) > 0 {
-			deltaMap := make(map[string]playerDelta, len(deltas))
-			for _, d := range deltas {
-				deltaMap[d.UserID] = d
-			}
+		} else {
 			room.mu.Lock()
-			room.gameDeltas = deltaMap
+			room.savedGameID = gameID
+			if len(deltas) > 0 {
+				deltaMap := make(map[string]playerDelta, len(deltas))
+				for _, d := range deltas {
+					deltaMap[d.UserID] = d
+				}
+				room.gameDeltas = deltaMap
+			}
 			room.mu.Unlock()
 		}
 	}
@@ -2205,7 +2392,21 @@ func (room *room) savedResultLocked(finishedAt time.Time) savedGameResult {
 	if startedAt.IsZero() {
 		startedAt = finishedAt
 	}
-	return savedGameResult{RoomID: room.id, StartedAt: startedAt, FinishedAt: finishedAt, Players: players}
+	var initialHands [][]savedCard
+	if len(room.moves) > 0 {
+		initialHands = make([][]savedCard, game.PlayerCount)
+		for i := range room.initialHands {
+			initialHands[i] = toSavedCards(room.initialHands[i])
+		}
+	}
+	return savedGameResult{
+		RoomID:       room.id,
+		StartedAt:    startedAt,
+		FinishedAt:   finishedAt,
+		Players:      players,
+		InitialHands: initialHands,
+		Moves:        toSavedMoves(room.moves),
+	}
 }
 
 func (room *room) results() []map[string]any {

--- a/services/ws/server_test.go
+++ b/services/ws/server_test.go
@@ -17,9 +17,9 @@ type memoryGameHistoryStore struct {
 	results []savedGameResult
 }
 
-func (store *memoryGameHistoryStore) SaveGame(result savedGameResult) ([]playerDelta, error) {
+func (store *memoryGameHistoryStore) SaveGame(result savedGameResult) (string, []playerDelta, error) {
 	store.results = append(store.results, result)
-	return nil, nil
+	return "", nil, nil
 }
 
 type staticRoomSettingsStore struct {
@@ -1499,7 +1499,7 @@ func aceCloseTestState() game.GameState {
 func TestApplyClientMessageClosesAceLowWithExplicitMethod(t *testing.T) {
 	state := aceCloseTestState()
 
-	updated, err := applyClientMessage(state, 0, clientMessage{
+	updated, _, err := applyClientMessage(state, 0, clientMessage{
 		Type: messageTypePlayCard, Suit: "spades", Rank: "A", Method: "low",
 	})
 	if err != nil {
@@ -1518,7 +1518,7 @@ func TestApplyClientMessageAceWithoutMethodIsAmbiguousWhenBothEnds(t *testing.T)
 	// guess which end, so it must ask the client to specify.
 	state := aceCloseTestState()
 
-	_, err := applyClientMessage(state, 0, clientMessage{
+	_, _, err := applyClientMessage(state, 0, clientMessage{
 		Type: messageTypePlayCard, Suit: "spades", Rank: "A",
 	})
 	if err == nil {
@@ -1534,7 +1534,7 @@ func TestApplyClientMessageAceWithoutMethodInfersSingleEnd(t *testing.T) {
 	state.Hands[0] = []game.Card{{Suit: game.Hearts, Rank: game.Ace}}
 	state.Board[game.Hearts] = game.SuitSequence{Low: game.Two, High: game.Nine}
 
-	updated, err := applyClientMessage(state, 0, clientMessage{
+	updated, _, err := applyClientMessage(state, 0, clientMessage{
 		Type: messageTypePlayCard, Suit: "hearts", Rank: "A",
 	})
 	if err != nil {
@@ -1549,7 +1549,7 @@ func TestApplyClientMessageAceWithoutMethodUsesLockedMethod(t *testing.T) {
 	state := aceCloseTestState()
 	state.CloseMethod = game.CloseLow
 
-	updated, err := applyClientMessage(state, 0, clientMessage{
+	updated, _, err := applyClientMessage(state, 0, clientMessage{
 		Type: messageTypePlayCard, Suit: "spades", Rank: "A",
 	})
 	if err != nil {
@@ -1569,7 +1569,7 @@ func TestApplyClientMessageAcePlayNeverExtendsBoard(t *testing.T) {
 	state.Hands[0] = []game.Card{{Suit: game.Spades, Rank: game.Ace}}
 	state.Board[game.Spades] = game.SuitSequence{Low: game.Five, High: game.Nine}
 
-	_, err := applyClientMessage(state, 0, clientMessage{
+	_, _, err := applyClientMessage(state, 0, clientMessage{
 		Type: messageTypePlayCard, Suit: "spades", Rank: "A",
 	})
 	if err == nil {

--- a/services/ws/store/store.go
+++ b/services/ws/store/store.go
@@ -44,17 +44,28 @@ type PersistedPlayer struct {
 // RoomSnapshot is the complete durable state of a room — enough to rebuild it
 // after a WS process restart.
 type RoomSnapshot struct {
-	State            game.GameState    `json:"state"`
-	Players          []PersistedPlayer `json:"players"`
-	Phase            int               `json:"phase"`
-	Started          bool              `json:"started"`
-	StartedAt        time.Time         `json:"started_at"`
-	TurnExpiresAt    time.Time         `json:"turn_expires_at"`
-	TurnTimerSeconds int               `json:"turn_timer_seconds"`
-	BotDifficulty    string            `json:"bot_difficulty,omitempty"`
-	PracticeMode     bool              `json:"practice_mode,omitempty"`
-	TurnTimerToken   int               `json:"turn_timer_token"`
-	RematchVotes     []int             `json:"rematch_votes"`
+	State            game.GameState                `json:"state"`
+	Players          []PersistedPlayer             `json:"players"`
+	Phase            int                           `json:"phase"`
+	Started          bool                          `json:"started"`
+	StartedAt        time.Time                     `json:"started_at"`
+	TurnExpiresAt    time.Time                     `json:"turn_expires_at"`
+	TurnTimerSeconds int                           `json:"turn_timer_seconds"`
+	BotDifficulty    string                        `json:"bot_difficulty,omitempty"`
+	PracticeMode     bool                          `json:"practice_mode,omitempty"`
+	TurnTimerToken   int                           `json:"turn_timer_token"`
+	RematchVotes     []int                         `json:"rematch_votes"`
+	InitialHands     [game.PlayerCount][]game.Card `json:"initial_hands,omitempty"`
+	Moves            []PersistedMove               `json:"moves,omitempty"`
+}
+
+// PersistedMove is the durable form of a single game move for replay recording.
+type PersistedMove struct {
+	PlayerIndex  int    `json:"player_index"`
+	Suit         string `json:"suit"`
+	Rank         int    `json:"rank"`
+	Type         string `json:"type"`
+	AceDirection string `json:"ace_direction,omitempty"`
 }
 
 // Store reads and writes [RoomSnapshot] values to Redis.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,6 +15,7 @@ import { ProfilePage } from "./pages/ProfilePage";
 import { MyProfilePage } from "./pages/MyProfilePage";
 import { ResultsPage } from "./pages/ResultsPage";
 import { SpectatorPage } from "./pages/SpectatorPage";
+import { ReplayPage } from "./pages/ReplayPage";
 import { WaitingRoomPage } from "./pages/WaitingRoomPage";
 import { AuthProvider } from "./hooks/AuthProvider";
 import { useAuth } from "./hooks/useAuth";
@@ -200,6 +201,7 @@ function AppShell() {
           <Route path="/players/:id" element={<ProfilePage />} />
           <Route path="/me" element={<MyProfilePage />} />
           <Route path="/watch/:roomId" element={<SpectatorPage />} />
+          <Route path="/replay/:gameId" element={<ReplayPage />} />
           <Route path="*" element={<Navigate replace to="/auth" />} />
         </Routes>
       </main>

--- a/web/src/api/history.ts
+++ b/web/src/api/history.ts
@@ -10,6 +10,7 @@ export type HistoryGameDto = {
   rank: number
   is_winner: boolean
   rating_delta?: number | null
+  replay_available?: boolean
 }
 
 export type HistoryResponse = {

--- a/web/src/api/replay.ts
+++ b/web/src/api/replay.ts
@@ -1,0 +1,37 @@
+import { apiRequest } from './client'
+
+export type ReplayCardDto = {
+  suit: string
+  rank: number
+}
+
+export type ReplayMoveDto = {
+  index: number
+  player_index: number
+  suit: string
+  rank: number
+  type: 'play' | 'face_down' | 'ace_close'
+  ace_direction?: 'low' | 'high' | ''
+}
+
+export type ReplayPlayerDto = {
+  player_index: number
+  display_name: string
+  is_bot: boolean
+  is_winner: boolean
+  rank: number
+}
+
+export type ReplayDto = {
+  game_id: string
+  room_name: string
+  started_at: string
+  finished_at: string
+  players: ReplayPlayerDto[]
+  initial_hands: ReplayCardDto[][]
+  moves: ReplayMoveDto[]
+}
+
+export function getReplay(token: string | null, gameId: string): Promise<ReplayDto> {
+  return apiRequest<ReplayDto>(`/games/${encodeURIComponent(gameId)}/replay`, { token })
+}

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -1,6 +1,7 @@
 import type { ButtonHTMLAttributes, ReactNode } from 'react'
 
 type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger'
+type ButtonSize = 'md' | 'sm' | 'xs'
 
 const variantClasses: Record<ButtonVariant, string> = {
   primary: 'bg-spade-gold text-[#1a0e00] hover:bg-[#d9a030]',
@@ -9,15 +10,30 @@ const variantClasses: Record<ButtonVariant, string> = {
   danger: 'bg-spade-red text-white hover:bg-[#922b21]',
 }
 
+// Size controls vertical metrics so a button can sit cleanly inside dense rows
+// (xs) without breaking row height. md matches the previous default exactly.
+const sizeClasses: Record<ButtonSize, string> = {
+  md: 'min-h-9 rounded-spade-md px-4 py-2 text-sm font-medium',
+  sm: 'min-h-7 rounded-spade-md px-3 py-1 text-xs font-medium',
+  xs: 'rounded-spade-sm px-2 py-0 text-xs font-medium leading-4',
+}
+
 type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   children: ReactNode
   variant?: ButtonVariant
+  size?: ButtonSize
 }
 
-export function Button({ children, variant = 'primary', className = '', ...props }: ButtonProps) {
+export function Button({
+  children,
+  variant = 'primary',
+  size = 'md',
+  className = '',
+  ...props
+}: ButtonProps) {
   return (
     <button
-      className={`inline-flex min-h-9 items-center justify-center rounded-spade-md px-4 py-2 text-sm font-medium transition active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 ${variantClasses[variant]} ${className}`}
+      className={`inline-flex items-center justify-center transition active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 ${sizeClasses[size]} ${variantClasses[variant]} ${className}`}
       {...props}
     >
       {children}

--- a/web/src/game/replay.test.ts
+++ b/web/src/game/replay.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import { reconstructAt } from './replay'
+import type { ReplayCardDto, ReplayMoveDto } from '../api/replay'
+
+// Build a stripped-down deal: each seat gets a few specific cards. The actual
+// distribution doesn't matter for these tests — only that the move log applies
+// cleanly to the hands we hand it.
+function deal(hands: ReplayCardDto[][]): ReplayCardDto[][] {
+  return hands
+}
+
+describe('reconstructAt', () => {
+  it('returns initial state at index -1 with no moves applied', () => {
+    const hands = deal([
+      [{ suit: 'spades', rank: 7 }, { suit: 'hearts', rank: 8 }],
+      [{ suit: 'hearts', rank: 7 }],
+      [{ suit: 'diamonds', rank: 7 }],
+      [{ suit: 'clubs', rank: 7 }],
+    ])
+    const state = reconstructAt(hands, [], -1)
+    expect(state.hands[0]).toHaveLength(2)
+    expect(state.hands[1]).toHaveLength(1)
+    expect(state.currentPlayer).toBe(0) // seat 0 holds 7♠
+    expect(state.closedSuits).toEqual([])
+    // No moves: board is empty (all rows have only null slots)
+    for (const row of state.boardRows) {
+      expect(row.cards.every((c) => c === null)).toBe(true)
+    }
+  })
+
+  it('applies a single play: removes from hand, extends board', () => {
+    const hands = deal([
+      [{ suit: 'spades', rank: 7 }],
+      [],
+      [],
+      [],
+    ])
+    const moves: ReplayMoveDto[] = [
+      { index: 0, player_index: 0, suit: 'spades', rank: 7, type: 'play' },
+    ]
+    const state = reconstructAt(hands, moves, 0)
+    expect(state.hands[0]).toHaveLength(0)
+    // The 7♠ slot (column 6 in the 14-slot board: A,2..K,A → index 6) is filled.
+    const spadesRow = state.boardRows.find((r) => r.suit === 'Spades')!
+    expect(spadesRow.cards[6]).toBe('7')
+  })
+
+  it('ace_close marks suit closed and records direction', () => {
+    // Seat 0 needs the Ace of spades, plus a played sequence reaching King.
+    // Simplest setup: 0 plays 7♠ then closes spades high.
+    const hands = deal([
+      [
+        { suit: 'spades', rank: 7 },
+        { suit: 'spades', rank: 8 },
+        { suit: 'spades', rank: 9 },
+        { suit: 'spades', rank: 10 },
+        { suit: 'spades', rank: 11 },
+        { suit: 'spades', rank: 12 },
+        { suit: 'spades', rank: 13 },
+        { suit: 'spades', rank: 14 }, // Ace
+      ],
+      [],
+      [],
+      [],
+    ])
+    const moves: ReplayMoveDto[] = [
+      { index: 0, player_index: 0, suit: 'spades', rank: 7, type: 'play' },
+      { index: 1, player_index: 0, suit: 'spades', rank: 8, type: 'play' },
+      { index: 2, player_index: 0, suit: 'spades', rank: 9, type: 'play' },
+      { index: 3, player_index: 0, suit: 'spades', rank: 10, type: 'play' },
+      { index: 4, player_index: 0, suit: 'spades', rank: 11, type: 'play' },
+      { index: 5, player_index: 0, suit: 'spades', rank: 12, type: 'play' },
+      { index: 6, player_index: 0, suit: 'spades', rank: 13, type: 'play' },
+      { index: 7, player_index: 0, suit: 'spades', rank: 14, type: 'ace_close', ace_direction: 'high' },
+    ]
+    const state = reconstructAt(hands, moves, 7)
+    expect(state.closedSuits).toContain('spades')
+    expect(state.aceCloseMethod).toBe('high')
+    const spadesRow = state.boardRows.find((r) => r.suit === 'Spades')!
+    // High Ace slot is column 13
+    expect(spadesRow.cards[13]).toBe('A')
+    expect(spadesRow.closed).toBe(true)
+  })
+
+  it('face_down moves card from hand to that seat\'s face-down pile', () => {
+    // Set up a non-stalemate scenario: seats 2 and 3 still have playable 7s
+    // after move 1, so the engine doesn't sweep remaining hands.
+    const hands = deal([
+      [{ suit: 'spades', rank: 7 }],
+      [{ suit: 'clubs', rank: 14 }], // dead Ace (clubs has no sequence yet)
+      [{ suit: 'diamonds', rank: 7 }],
+      [{ suit: 'hearts', rank: 7 }],
+    ])
+    const moves: ReplayMoveDto[] = [
+      { index: 0, player_index: 0, suit: 'spades', rank: 7, type: 'play' },
+      { index: 1, player_index: 1, suit: 'clubs', rank: 14, type: 'face_down' },
+    ]
+    const state = reconstructAt(hands, moves, 1)
+    expect(state.hands[1]).toHaveLength(0)
+    expect(state.faceDown[1]).toEqual([{ suit: 'clubs', rank: 14 }])
+  })
+
+  it('stepping backwards reconstructs the same state', () => {
+    const hands = deal([
+      [{ suit: 'spades', rank: 7 }, { suit: 'spades', rank: 8 }],
+      [],
+      [],
+      [],
+    ])
+    const moves: ReplayMoveDto[] = [
+      { index: 0, player_index: 0, suit: 'spades', rank: 7, type: 'play' },
+      { index: 1, player_index: 0, suit: 'spades', rank: 8, type: 'play' },
+    ]
+    const after0a = reconstructAt(hands, moves, 0)
+    const after0b = reconstructAt(hands, moves, 0)
+    expect(after0a.hands[0]).toEqual(after0b.hands[0])
+    expect(after0a.boardRows).toEqual(after0b.boardRows)
+  })
+})

--- a/web/src/game/replay.ts
+++ b/web/src/game/replay.ts
@@ -1,0 +1,284 @@
+import type { BoardRow } from '../types'
+import type { ReplayCardDto, ReplayMoveDto } from '../api/replay'
+import { buildBoardRows } from '../hooks/useGameSocket'
+import { wireSuitToSuit } from './cards'
+
+const PLAYER_COUNT = 4
+
+// ReplayState is the reconstructed game state at a single point in the move
+// sequence. It mirrors the shape that GameBoard/CardFace expect.
+export type ReplayState = {
+  boardRows: BoardRow[]
+  hands: ReplayCardDto[][]
+  faceDown: ReplayCardDto[][]
+  currentPlayer: number
+  closedSuits: string[]
+  aceCloseMethod: string
+}
+
+type InternalCard = { suit: string; rank: number }
+type SuitSequence = { low: number; high: number }
+
+function removeCard(hand: InternalCard[], suit: string, rank: number): InternalCard[] {
+  const idx = hand.findIndex((c) => c.suit === suit && c.rank === rank)
+  if (idx === -1) return hand
+  return [...hand.slice(0, idx), ...hand.slice(idx + 1)]
+}
+
+function nextPlayerWithCards(hands: InternalCard[][], current: number): number {
+  for (let offset = 1; offset <= PLAYER_COUNT; offset++) {
+    const candidate = (current + offset) % PLAYER_COUNT
+    if (hands[candidate].length > 0) return candidate
+  }
+  return current
+}
+
+function isGameOver(hands: InternalCard[][]): boolean {
+  return hands.every((h) => h.length === 0)
+}
+
+function isStalemate(
+  hands: InternalCard[][],
+  board: Record<string, SuitSequence | null>,
+  closed: Set<string>,
+): boolean {
+  if (isGameOver(hands)) return false
+  for (const hand of hands) {
+    if (hand.length === 0) continue
+    const boardEmpty = Object.values(board).every((v) => v === null)
+    for (const card of hand) {
+      if (card.rank === 14) continue
+      if (closed.has(card.suit)) continue
+      const seq = board[card.suit]
+      if (!seq) {
+        if (boardEmpty && card.suit === 'spades' && card.rank === 7) return false
+        if (!boardEmpty && card.rank === 7) return false
+        continue
+      }
+      if (card.rank === seq.low - 1 || card.rank === seq.high + 1) return false
+    }
+    // check ace closes
+    for (const card of hand) {
+      if (card.rank !== 14) continue
+      if (closed.has(card.suit)) continue
+      const seq = board[card.suit]
+      if (!seq) continue
+      if (seq.low === 2 || seq.high === 13) return false
+    }
+  }
+  return true
+}
+
+function finalizeStalemate(hands: InternalCard[][], faceDown: InternalCard[][]): {
+  hands: InternalCard[][]
+  faceDown: InternalCard[][]
+} {
+  const newHands = hands.map(() => [] as InternalCard[])
+  const newFaceDown = faceDown.map((pile, i) => [...pile, ...hands[i]])
+  return { hands: newHands, faceDown: newFaceDown }
+}
+
+function applyCardToSequence(
+  seq: SuitSequence | null,
+  rank: number,
+): SuitSequence {
+  if (!seq) return { low: rank, high: rank }
+  return { low: Math.min(seq.low, rank), high: Math.max(seq.high, rank) }
+}
+
+// initialReplayState builds the state at move index -1 (before any move).
+export function initialReplayState(initialHands: ReplayCardDto[][]): ReplayState {
+  const hands: InternalCard[][] = initialHands.map((hand) =>
+    hand.map((c) => ({ suit: c.suit, rank: c.rank })),
+  )
+  const faceDown: InternalCard[][] = Array.from({ length: PLAYER_COUNT }, () => [])
+  const board: Record<string, SuitSequence | null> = {
+    spades: null,
+    hearts: null,
+    diamonds: null,
+    clubs: null,
+  }
+
+  // find the starter: holder of 7♠
+  let currentPlayer = 0
+  for (let i = 0; i < hands.length; i++) {
+    if (hands[i].some((c) => c.suit === 'spades' && c.rank === 7)) {
+      currentPlayer = i
+      break
+    }
+  }
+
+  return toReplayState(hands, faceDown, board, new Set(), '', currentPlayer)
+}
+
+function toReplayState(
+  hands: InternalCard[][],
+  faceDown: InternalCard[][],
+  board: Record<string, SuitSequence | null>,
+  closed: Set<string>,
+  aceCloseMethod: string,
+  currentPlayer: number,
+): ReplayState {
+  const wireBoardRange: Record<string, { low: number | string; high: number | string } | null> = {}
+  for (const suit of ['spades', 'hearts', 'diamonds', 'clubs']) {
+    const seq = board[suit]
+    wireBoardRange[suit] = seq ? { low: seq.low, high: seq.high } : null
+  }
+  const boardRows = buildBoardRows(wireBoardRange, Array.from(closed), aceCloseMethod)
+  return {
+    boardRows,
+    hands: hands.map((h) => h.map((c) => ({ suit: c.suit, rank: c.rank }))),
+    faceDown: faceDown.map((pile) => pile.map((c) => ({ suit: c.suit, rank: c.rank }))),
+    currentPlayer,
+    closedSuits: Array.from(closed),
+    aceCloseMethod,
+  }
+}
+
+// applyMove applies a single recorded move to the current internal state and
+// returns the resulting ReplayState.
+function applyMoveToState(
+  hands: InternalCard[][],
+  faceDown: InternalCard[][],
+  board: Record<string, SuitSequence | null>,
+  closed: Set<string>,
+  aceCloseMethod: string,
+  move: ReplayMoveDto,
+): ReplayState {
+  let newHands = hands.map((h) => [...h])
+  let newFaceDown = faceDown.map((pile) => [...pile])
+  const newBoard = { ...board }
+  const newClosed = new Set(closed)
+  let newAceCloseMethod = aceCloseMethod
+  let newCurrentPlayer: number
+
+  const { player_index, suit, rank, type, ace_direction } = move
+
+  if (type === 'ace_close') {
+    newHands[player_index] = removeCard(newHands[player_index], suit, rank)
+    newClosed.add(suit)
+    if (!newAceCloseMethod && ace_direction) {
+      newAceCloseMethod = ace_direction
+    }
+    newCurrentPlayer = nextPlayerWithCards(newHands, player_index)
+  } else if (type === 'play') {
+    newHands[player_index] = removeCard(newHands[player_index], suit, rank)
+    newBoard[suit] = applyCardToSequence(newBoard[suit], rank)
+    newCurrentPlayer = nextPlayerWithCards(newHands, player_index)
+  } else {
+    // face_down
+    newHands[player_index] = removeCard(newHands[player_index], suit, rank)
+    newFaceDown[player_index] = [...newFaceDown[player_index], { suit, rank }]
+    newCurrentPlayer = nextPlayerWithCards(newHands, player_index)
+  }
+
+  // finalizeIfStalemate
+  if (isStalemate(newHands, newBoard, newClosed)) {
+    const result = finalizeStalemate(newHands, newFaceDown)
+    newHands = result.hands
+    newFaceDown = result.faceDown
+  }
+
+  return toReplayState(newHands, newFaceDown, newBoard, newClosed, newAceCloseMethod, newCurrentPlayer)
+}
+
+// reconstructAt returns the replay state after applying moves[0..index]
+// (inclusive). Pass index -1 to get the initial deal state.
+export function reconstructAt(
+  initialHands: ReplayCardDto[][],
+  moves: ReplayMoveDto[],
+  index: number,
+): ReplayState {
+  const hands: InternalCard[][] = initialHands.map((hand) =>
+    hand.map((c) => ({ suit: c.suit, rank: c.rank })),
+  )
+  const faceDown: InternalCard[][] = Array.from({ length: PLAYER_COUNT }, () => [])
+  const board: Record<string, SuitSequence | null> = {
+    spades: null,
+    hearts: null,
+    diamonds: null,
+    clubs: null,
+  }
+  const closed = new Set<string>()
+  const aceCloseMethod = ''
+
+  // find starter
+  let currentPlayer = 0
+  for (let i = 0; i < hands.length; i++) {
+    if (hands[i].some((c) => c.suit === 'spades' && c.rank === 7)) {
+      currentPlayer = i
+      break
+    }
+  }
+
+  let state = toReplayState(hands, faceDown, board, closed, aceCloseMethod, currentPlayer)
+
+  const limit = Math.min(index, moves.length - 1)
+  for (let i = 0; i <= limit; i++) {
+    // re-derive mutable state from the previous step
+    const curHands: InternalCard[][] = state.hands.map((h) => h.map((c) => ({ ...c })))
+    const curFaceDown: InternalCard[][] = state.faceDown.map((pile) =>
+      pile.map((c) => ({ ...c })),
+    )
+    const curBoard: Record<string, SuitSequence | null> = {}
+    for (const suit of ['spades', 'hearts', 'diamonds', 'clubs']) {
+      const seq = state.boardRows.find(
+        (r) => r.suit === wireSuitToSuit[suit],
+      )
+      if (seq) {
+        const filled = seq.cards.slice(1, 13).map((v, idx) => ({ rank: idx + 2, present: v !== null }))
+        const played = filled.filter((v) => v.present)
+        if (played.length > 0) {
+          curBoard[suit] = { low: played[0].rank, high: played[played.length - 1].rank }
+        } else {
+          curBoard[suit] = null
+        }
+      } else {
+        curBoard[suit] = null
+      }
+    }
+    const curClosed = new Set(state.closedSuits)
+    state = applyMoveToState(
+      curHands,
+      curFaceDown,
+      curBoard,
+      curClosed,
+      state.aceCloseMethod,
+      moves[i],
+    )
+  }
+
+  return state
+}
+
+// rankLabel converts an engine rank int to a display string (e.g. 14 -> "A").
+export function rankLabel(rank: number): string {
+  if (rank === 14) return 'A'
+  if (rank === 13) return 'K'
+  if (rank === 12) return 'Q'
+  if (rank === 11) return 'J'
+  return String(rank)
+}
+
+// suitSymbol converts an engine suit string to a unicode symbol.
+export function replaySuitSymbol(suit: string): string {
+  const symbols: Record<string, string> = {
+    spades: '♠',
+    hearts: '♥',
+    diamonds: '♦',
+    clubs: '♣',
+  }
+  return symbols[suit] ?? suit
+}
+
+// moveLabel returns a human-readable description of a move.
+export function moveLabel(move: ReplayMoveDto): string {
+  const card = `${rankLabel(move.rank)}${replaySuitSymbol(move.suit)}`
+  if (move.type === 'ace_close') {
+    return `${card} closes ${move.suit} (${move.ace_direction})`
+  }
+  if (move.type === 'face_down') {
+    return `${card} face down`
+  }
+  return card
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -48,12 +48,6 @@ body {
   margin: 0;
 }
 
-button,
-input,
-select {
-  font: inherit;
-}
-
 * {
   box-sizing: border-box;
 }

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -122,7 +122,7 @@ export function HistoryPage() {
                     <Button
                       variant="ghost"
                       onClick={() => navigate(`/replay/${game.game_id}`)}
-                      className="!min-h-0 px-2 py-0.5 text-xs"
+                      className="!min-h-0 !border-0 !bg-spade-gold/10 !px-2 !py-0 !text-xs !font-normal !leading-4"
                     >
                       Replay
                     </Button>

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -103,6 +103,7 @@ export function HistoryPage() {
               <th className="px-2 py-2">Penalty</th>
               <th className="px-2 py-2">Rating</th>
               <th className="px-4 py-2">Finished</th>
+              <th className="px-2 py-2">Replay</th>
             </tr>
           </thead>
           <tbody>
@@ -116,11 +117,20 @@ export function HistoryPage() {
                   {game.rating_delta != null ? `${game.rating_delta >= 0 ? '+' : ''}${game.rating_delta}` : '—'}
                 </td>
                 <td className="px-4 py-3 text-xs text-spade-gray-2">{formatDate(game.finished_at)}</td>
+                <td className="px-2 py-3">
+                  {game.replay_available ? (
+                    <Button variant="ghost" onClick={() => navigate(`/replay/${game.game_id}`)}>
+                      Replay
+                    </Button>
+                  ) : (
+                    <span className="text-xs text-spade-gray-3">—</span>
+                  )}
+                </td>
               </tr>
             ))}
             {!isLoading && games.length === 0 ? (
               <tr className="border-t border-spade-cream/8">
-                <td colSpan={6} className="px-4 py-8 text-center text-sm text-spade-gray-2">
+                <td colSpan={7} className="px-4 py-8 text-center text-sm text-spade-gray-2">
                   No completed games yet.
                 </td>
               </tr>

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -121,8 +121,8 @@ export function HistoryPage() {
                   {game.replay_available ? (
                     <Button
                       variant="ghost"
+                      size="xs"
                       onClick={() => navigate(`/replay/${game.game_id}`)}
-                      className="!min-h-0 !border-0 !bg-spade-gold/10 !px-2 !py-0 !text-xs !font-normal !leading-4"
                     >
                       Replay
                     </Button>

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -119,13 +119,13 @@ export function HistoryPage() {
                 <td className="px-4 py-3 text-xs text-spade-gray-2">{formatDate(game.finished_at)}</td>
                 <td className="px-2 py-3">
                   {game.replay_available ? (
-                    <button
-                      type="button"
+                    <Button
+                      variant="ghost"
                       onClick={() => navigate(`/replay/${game.game_id}`)}
-                      className="inline-flex items-center rounded-spade-sm border border-spade-gold/60 px-2 py-0.5 text-xs font-medium text-spade-gold-light transition hover:bg-spade-gold/10"
+                      className="!min-h-0 px-2 py-0.5 text-xs"
                     >
                       Replay
-                    </button>
+                    </Button>
                   ) : (
                     <span className="text-xs text-spade-gray-3">—</span>
                   )}

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -119,9 +119,13 @@ export function HistoryPage() {
                 <td className="px-4 py-3 text-xs text-spade-gray-2">{formatDate(game.finished_at)}</td>
                 <td className="px-2 py-3">
                   {game.replay_available ? (
-                    <Button variant="ghost" onClick={() => navigate(`/replay/${game.game_id}`)}>
+                    <button
+                      type="button"
+                      onClick={() => navigate(`/replay/${game.game_id}`)}
+                      className="inline-flex items-center rounded-spade-sm border border-spade-gold/60 px-2 py-0.5 text-xs font-medium text-spade-gold-light transition hover:bg-spade-gold/10"
+                    >
                       Replay
-                    </Button>
+                    </button>
                   ) : (
                     <span className="text-xs text-spade-gray-3">—</span>
                   )}

--- a/web/src/pages/ReplayPage.tsx
+++ b/web/src/pages/ReplayPage.tsx
@@ -1,0 +1,318 @@
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate, useParams, Link } from 'react-router'
+import { GameBoard } from '../components/GameBoard'
+import { Button } from '../components/Button'
+import { SceneShell } from '../components/SceneShell'
+import { useAuth } from '../hooks/useAuth'
+import { getReplay } from '../api/replay'
+import type { ReplayDto } from '../api/replay'
+import { reconstructAt, rankLabel, replaySuitSymbol } from '../game/replay'
+import type { ReplayState } from '../game/replay'
+import { initialsForName } from '../game/cards'
+
+const SPEEDS = [1, 2, 4] as const
+type Speed = (typeof SPEEDS)[number]
+const INTERVAL_MS: Record<Speed, number> = { 1: 1200, 2: 600, 4: 300 }
+
+export function ReplayPage() {
+  const { gameId } = useParams()
+  const navigate = useNavigate()
+  const { token, isAuthenticated } = useAuth()
+
+  const [replay, setReplay] = useState<ReplayDto | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [index, setIndex] = useState(-1)
+  const [playing, setPlaying] = useState(false)
+  const [speed, setSpeed] = useState<Speed>(1)
+
+  const moveListRef = useRef<HTMLDivElement>(null)
+  const intervalRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (!isAuthenticated) navigate('/auth', { replace: true })
+  }, [isAuthenticated, navigate])
+
+  useEffect(() => {
+    if (!gameId || !token) return
+    let cancelled = false
+    getReplay(token, gameId)
+      .then((data) => {
+        if (cancelled) return
+        setReplay(data)
+        setIndex(-1)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setError(err?.message ?? 'Failed to load replay')
+      })
+      .finally(() => {
+        if (cancelled) return
+        setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [gameId, token])
+
+  const totalMoves = replay?.moves.length ?? 0
+
+  useEffect(() => {
+    if (!playing || !replay) return
+    intervalRef.current = window.setInterval(() => {
+      setIndex((prev) => {
+        if (prev >= totalMoves - 1) {
+          setPlaying(false)
+          return prev
+        }
+        return prev + 1
+      })
+    }, INTERVAL_MS[speed])
+    return () => {
+      if (intervalRef.current !== null) window.clearInterval(intervalRef.current)
+    }
+  }, [playing, speed, totalMoves, replay])
+
+  // Scroll active move into view
+  useEffect(() => {
+    if (!moveListRef.current) return
+    const active = moveListRef.current.querySelector('[data-active="true"]')
+    active?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+  }, [index])
+
+  if (loading) {
+    return (
+      <SceneShell title="Replay" eyebrow="Loading…">
+        <div className="py-12 text-center text-sm text-spade-gray-2">Loading replay…</div>
+      </SceneShell>
+    )
+  }
+
+  if (error || !replay) {
+    return (
+      <SceneShell title="Replay" eyebrow="Not available">
+        <div className="grid gap-4 py-8 text-center">
+          <p className="text-sm text-spade-gray-2">
+            {error ?? 'Replay not available for this game.'}
+          </p>
+          <div className="flex justify-center">
+            <Button variant="secondary" onClick={() => navigate(-1)}>Go back</Button>
+          </div>
+        </div>
+      </SceneShell>
+    )
+  }
+
+  const state: ReplayState = reconstructAt(replay.initial_hands, replay.moves, index)
+
+  const handlePlay = () => setPlaying((p) => !p)
+  const handleStepBack = () => {
+    setPlaying(false)
+    setIndex((prev) => Math.max(-1, prev - 1))
+  }
+  const handleStepForward = () => {
+    setPlaying(false)
+    setIndex((prev) => Math.min(totalMoves - 1, prev + 1))
+  }
+  const handleScrub = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPlaying(false)
+    setIndex(Number(e.target.value))
+  }
+  const handleSpeedCycle = () => {
+    const idx = SPEEDS.indexOf(speed)
+    setSpeed(SPEEDS[(idx + 1) % SPEEDS.length])
+  }
+
+  const roomLabel = replay.room_name || replay.game_id.slice(0, 8)
+  const playerName = (idx: number) => replay.players[idx]?.display_name ?? `Player ${idx + 1}`
+  const currentPlayerName = state.currentPlayer >= 0 ? playerName(state.currentPlayer) : null
+
+  const isAtEnd = index === totalMoves - 1
+
+  return (
+    <SceneShell
+      title={`Replay — ${roomLabel}`}
+      eyebrow="Game Replay"
+      action={
+        <Button variant="secondary" onClick={() => navigate(-1)}>
+          ← Back
+        </Button>
+      }
+    >
+      <div className="grid gap-4 lg:grid-cols-[1fr_280px]">
+        {/* Board + controls */}
+        <div className="grid gap-3">
+          {/* Players row */}
+          <div className="flex flex-wrap items-end justify-center gap-3">
+            {replay.players.map((p) => {
+              const isActive = state.currentPlayer === p.player_index && !isAtEnd
+              const handCount = state.hands[p.player_index]?.length ?? 0
+              const faceDownCount = state.faceDown[p.player_index]?.length ?? 0
+              return (
+                <div
+                  key={p.player_index}
+                  className={`flex flex-col items-center gap-1 rounded-spade-lg border px-3 py-2 text-xs transition ${
+                    isActive
+                      ? 'border-spade-gold/60 bg-spade-bg/60 shadow-[0_0_10px_rgba(212,175,55,0.3)]'
+                      : 'border-spade-cream/10 bg-spade-bg/30'
+                  }`}
+                >
+                  <div className="size-8 rounded-full bg-spade-cream/10 grid place-items-center text-[11px] font-bold text-spade-cream">
+                    {initialsForName(p.display_name)}
+                  </div>
+                  <span className="max-w-[72px] truncate font-medium text-spade-cream">{p.display_name}</span>
+                  <div className="flex gap-2 text-[10px] text-spade-gray-3">
+                    <span title="Cards in hand">🃏 {handCount}</span>
+                    <span title="Face-down cards">⬇ {faceDownCount}</span>
+                  </div>
+                  {p.is_winner && (
+                    <span className="text-[9px] font-semibold text-spade-gold">Winner</span>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+
+          {/* Board */}
+          <div className="mx-auto w-full max-w-[820px]">
+            <GameBoard rows={state.boardRows} />
+          </div>
+
+          {/* Turn indicator */}
+          <div className="text-center text-xs text-spade-gray-2">
+            {isAtEnd
+              ? 'Game over'
+              : index === -1
+              ? 'Initial deal — no moves yet'
+              : currentPlayerName
+              ? `${currentPlayerName}'s turn`
+              : null}
+          </div>
+
+          {/* Playback controls */}
+          <div className="mx-auto flex w-full max-w-[820px] flex-col gap-2">
+            <input
+              type="range"
+              min={-1}
+              max={totalMoves - 1}
+              value={index}
+              onChange={handleScrub}
+              className="w-full accent-spade-gold"
+              aria-label="Move scrubber"
+            />
+            <div className="flex items-center justify-center gap-2">
+              <Button variant="secondary" onClick={handleStepBack} disabled={index <= -1} aria-label="Step back">
+                ‹
+              </Button>
+              <Button variant={playing ? 'ghost' : 'primary'} onClick={handlePlay} disabled={isAtEnd}>
+                {playing ? '⏸ Pause' : '▶ Play'}
+              </Button>
+              <Button variant="secondary" onClick={handleStepForward} disabled={isAtEnd} aria-label="Step forward">
+                ›
+              </Button>
+              <Button variant="secondary" onClick={handleSpeedCycle} aria-label="Playback speed">
+                {speed}×
+              </Button>
+            </div>
+            <p className="text-center font-mono text-[10px] text-spade-gray-3">
+              {index === -1 ? 'Deal' : `Move ${index + 1} / ${totalMoves}`}
+            </p>
+          </div>
+        </div>
+
+        {/* Move list sidebar */}
+        <div className="flex flex-col gap-2">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-spade-gray-2">
+            Move list
+          </h3>
+          <div
+            ref={moveListRef}
+            className="max-h-[480px] overflow-y-auto rounded-spade-lg border border-spade-cream/10 bg-spade-bg/50"
+          >
+            {/* Deal row */}
+            <button
+              type="button"
+              data-active={index === -1 ? 'true' : 'false'}
+              onClick={() => { setPlaying(false); setIndex(-1) }}
+              className={`w-full px-3 py-1.5 text-left text-xs transition ${
+                index === -1
+                  ? 'bg-spade-gold/15 text-spade-gold'
+                  : 'text-spade-gray-2 hover:bg-spade-cream/5'
+              }`}
+            >
+              <span className="font-mono text-[10px] text-spade-gray-3 mr-2">0</span>
+              Initial deal
+            </button>
+
+            {replay.moves.map((move, i) => {
+              const isActive = index === i
+              const name = playerName(move.player_index)
+              const suit = move.suit
+              const suitColors: Record<string, string> = {
+                hearts: 'text-spade-red',
+                diamonds: 'text-spade-red',
+                spades: 'text-spade-cream',
+                clubs: 'text-spade-cream',
+              }
+              const suitClass = suitColors[suit] ?? 'text-spade-cream'
+              return (
+                <button
+                  key={i}
+                  type="button"
+                  data-active={isActive ? 'true' : 'false'}
+                  onClick={() => { setPlaying(false); setIndex(i) }}
+                  className={`w-full border-t border-spade-cream/5 px-3 py-1.5 text-left text-xs transition ${
+                    isActive
+                      ? 'bg-spade-gold/15 text-spade-gold'
+                      : 'text-spade-gray-2 hover:bg-spade-cream/5'
+                  }`}
+                >
+                  <span className="font-mono text-[10px] text-spade-gray-3 mr-2">{i + 1}</span>
+                  <span className="mr-1 font-medium text-spade-cream">{name}</span>
+                  <span className={`font-mono font-bold ${suitClass}`}>
+                    {rankLabel(move.rank)}{replaySuitSymbol(move.suit)}
+                  </span>
+                  {move.type === 'face_down' && (
+                    <span className="ml-1 text-[9px] text-spade-gray-3">face-down</span>
+                  )}
+                  {move.type === 'ace_close' && (
+                    <span className="ml-1 text-[9px] text-spade-gold">closes ({move.ace_direction})</span>
+                  )}
+                </button>
+              )
+            })}
+          </div>
+
+          {/* Game summary */}
+          <div className="mt-2 rounded-spade-lg border border-spade-cream/10 bg-spade-bg/40 p-3">
+            <h4 className="mb-2 text-[10px] font-semibold uppercase tracking-wide text-spade-gray-3">
+              Final standings
+            </h4>
+            {[...replay.players]
+              .sort((a, b) => a.rank - b.rank)
+              .map((p) => (
+                <div key={p.player_index} className="flex items-center justify-between py-0.5 text-xs">
+                  <span className="text-spade-cream">
+                    {p.rank}. {p.display_name}
+                    {p.is_winner && <span className="ml-1 text-spade-gold">★</span>}
+                  </span>
+                </div>
+              ))}
+          </div>
+
+          {/* Share link */}
+          <p className="text-center text-[10px] text-spade-gray-3">
+            Shareable link:{' '}
+            <Link
+              to={`/replay/${gameId}`}
+              className="text-spade-gold-light underline underline-offset-2"
+            >
+              /replay/{gameId?.slice(0, 8)}…
+            </Link>
+          </p>
+        </div>
+      </div>
+    </SceneShell>
+  )
+}


### PR DESCRIPTION
Closes #44.

## Summary

Records every move during a game and lets players replay finished games
with a step-by-step viewer.

**Backend**
- WS captures the initial dealt hands + an ordered move log per game,
  persists them to the Redis room snapshot for restart durability, and
  ships them along the existing `POST /internal/games` request (no new
  internal endpoint).
- API stores them in two new tables via migration `024_game_replays.sql`
  (`game_moves`, `game_initial_hands`), atomic with the existing
  `SaveGame` transaction. `GET /games/:id/replay` returns the full
  replay payload to any authenticated user (shareable links).
- `game_over` WS message now carries `game_id` so finished-room views
  can link to the replay.

**Web**
- `/replay/:gameId` route with a read-only viewer that reuses
  `GameBoard` + `CardFace`. Playback controls (play/pause, step,
  scrubber, 1x/2x/4x) and a clickable move-list sidebar with the
  current move highlighted.
- Pure `web/src/game/replay.ts` reducer folds the move log over the
  dealt hands to derive board / hands / face-down piles at any step.
  No Go RNG to port to JS — exact and unit-tested.
- History list shows a "Replay" cell when replay data exists.

## Scope deltas
- **Retention**: replay data is kept only for the **20 most recent
  finished games globally** and pruned on every save inside the
  `SaveGame` transaction. Older games surface "replay unavailable" via
  the new `replay_available` flag on `GET /history`.
- **Initial hands** are stored as JSONB (not just a seed), so the JS
  reducer doesn't need to mirror Go's `math/rand` shuffle.
- **Mobile replay screen deferred** to a follow-up slice — the pure
  logic + API client are portable as-is; only the RN UI shell is
  missing.

## What was tested

- `services/ws`: `go test ./...` — 154 passed (1 unrelated relay test
  flaked on retry; passes on rerun).
- `services/api`: `go test ./...` — 177 passed, including the
  `SaveGame` mock with the new prune `DELETE`s.
- `web`: `npm test` — 162 passed, **5 new tests in `game/replay.test.ts`**
  covering initial state, play, ace_close, face_down, and back-step
  idempotency. (1 pre-existing `BadgeGrid` failure unchanged from
  `main`.)
- `npm run build` and `npm run lint` clean.

## Manual sanity check
1. Finish a game (any mode that saves history).
2. Open History → row shows "Replay".
3. Click → `/replay/<gameId>` opens, scrub through every move, watch
   hand counts go down and the board fill up. Ace closes flip the suit
   "Closed" badge and place the Ace in the correct end slot.

## Roadmap
Flipped `docs/roadmap.md` line 145 to ✅.