### PR TITLE
feat: card play animations (#48)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -151,7 +151,7 @@ All backlog items are tracked as GitHub issues in the [Post-MVP Features](https:
 
 | 🔲 | Issue | Effort |
 |---|---|---|
-| 🔲 | [#48](https://github.com/faytranevozter/7spade/issues/48) Card Play Animations | Medium |
+| ✅ | [#48](https://github.com/faytranevozter/7spade/issues/48) Card Play Animations | Medium |
 | 🔲 | [#50](https://github.com/faytranevozter/7spade/issues/50) Push Notifications (Mobile) | Medium |
 | ✅ | [#49](https://github.com/faytranevozter/7spade/issues/49) Configurable Leaderboard Sort | Low |
 | ✅ | [#51](https://github.com/faytranevozter/7spade/issues/51) User Search Beyond Exact Match | Low |

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,9 +22,25 @@ import { useAuth } from "./hooks/useAuth";
 import { ActiveRoomProvider } from "./hooks/ActiveRoomProvider";
 import { ActiveGameButton } from "./components/ActiveGameButton";
 import { useSound } from "./hooks/useSound";
+import { useMotion } from "./hooks/useMotion";
+import { type MotionSpeed } from "./game/motion";
 import { deleteLogout } from "./api/auth";
 import { getFriends } from "./api/friends";
 import { decodeJwtClaims } from "./auth/claims";
+
+// Header control labels for the card-animation speed cycle button.
+const MOTION_LABELS: Record<MotionSpeed, string> = {
+  off: "Off",
+  slow: "Slow",
+  normal: "Normal",
+  fast: "Fast",
+};
+const MOTION_ICONS: Record<MotionSpeed, string> = {
+  off: "⏸",
+  slow: "🐢",
+  normal: "🎬",
+  fast: "⚡",
+};
 
 // RedirectIfAuthenticated keeps logged-in users off the login/register pages.
 // Visiting them (via the Back button or a typed URL) bounces to the lobby.
@@ -97,6 +113,7 @@ function AppShell() {
   const navigate = useNavigate();
   const { token, isAuthenticated, isLoading, logout } = useAuth();
   const { muted, supported: soundSupported, toggleMuted } = useSound();
+  const { speed: motionSpeed, cycle: cycleMotion } = useMotion();
   const incomingRequests = useIncomingFriendRequests(token, isAuthenticated);
   const hideHeader = pathname === "/auth" || pathname === "/register" || pathname === "/login" || pathname.startsWith("/auth/callback");
 
@@ -159,6 +176,15 @@ function AppShell() {
                   <NavLink to="/me" className={navClass}>Profile</NavLink>
                 </nav>
                 <div className="flex items-center gap-2 rounded-spade-pill border border-spade-cream/10 bg-[#06110b]/55 p-1">
+                  <button
+                    type="button"
+                    onClick={cycleMotion}
+                    aria-label={`Card animations: ${MOTION_LABELS[motionSpeed]}`}
+                    title={`Card animations: ${MOTION_LABELS[motionSpeed]} (click to change)`}
+                    className={utilityClass}
+                  >
+                    {MOTION_ICONS[motionSpeed]}
+                  </button>
                   <button
                     type="button"
                     onClick={toggleMuted}

--- a/web/src/components/CardFace.tsx
+++ b/web/src/components/CardFace.tsx
@@ -8,6 +8,10 @@ type CardFaceProps = {
   interactive?: boolean
   onClick?: () => void
   ariaLabel?: string
+  // Optional animation utility class (e.g. 'anim-card-land', 'anim-ace-glow').
+  // Applied to the card root; the CSS keyframes are gated by the motion
+  // preference, so passing one is a no-op when animations are off.
+  animationClassName?: string
 }
 
 const sizeClasses = {
@@ -16,7 +20,7 @@ const sizeClasses = {
   board: 'aspect-[48/68] size-full',
 }
 
-export function CardFace({ card, size = 'md', onDark = true, interactive = true, onClick, ariaLabel }: CardFaceProps) {
+export function CardFace({ card, size = 'md', onDark = true, interactive = true, onClick, ariaLabel, animationClassName = '' }: CardFaceProps) {
   const tone = suitColorClass[card.suit]
   const label = `${card.rank} of ${card.suit}`
   const selected = card.selected ? '-translate-y-3 ring-2 ring-spade-gold' : ''
@@ -35,7 +39,7 @@ export function CardFace({ card, size = 'md', onDark = true, interactive = true,
       aria-label={ariaLabel ?? (card.playable ? `Play ${label}` : label)}
       data-playable={card.playable ? 'true' : 'false'}
       data-selected={card.selected ? 'true' : 'false'}
-      className={`relative shrink-0 rounded-[10px] bg-spade-white text-left ${sizeClasses[size]} ${selected} ${playable} ${dimmed} ${shadow} ${interaction} transition duration-150 ease-spade-spring`}
+      className={`relative shrink-0 rounded-[10px] bg-spade-white text-left ${sizeClasses[size]} ${selected} ${playable} ${dimmed} ${shadow} ${interaction} ${animationClassName} transition duration-150 ease-spade-spring`}
     >
       <span className={`absolute left-[12%] top-[8%] flex flex-col leading-none ${tone}`}>
         <span className="text-[clamp(10px,28%,14px)] font-bold">{card.rank}</span>

--- a/web/src/components/GameBoard.tsx
+++ b/web/src/components/GameBoard.tsx
@@ -42,6 +42,11 @@ export function GameBoard({ rows = emptyBoardRows() }: { rows?: BoardRow[] }) {
             <div className={`grid grid-cols-14 gap-1 transition-opacity ${row.closed ? "opacity-60" : ""}`}>
               {row.cards.map((rank, index) => {
                 const isAceColumn = index === 0 || index === row.cards.length - 1
+                // The CardFace only mounts when a slot fills, so a CSS "both"
+                // animation plays exactly once on landing (re-renders don't
+                // restart it). Ace columns glow (suit closed with an Ace);
+                // other columns slide/scale in. Gated by the motion preference.
+                const animationClassName = isAceColumn ? "anim-ace-glow" : "anim-card-land"
                 return (
                   <div
                     key={`${row.suit}-${index}`}
@@ -57,6 +62,7 @@ export function GameBoard({ rows = emptyBoardRows() }: { rows?: BoardRow[] }) {
                         size="board"
                         onDark
                         interactive={false}
+                        animationClassName={animationClassName}
                       />
                     ) : null}
                   </div>

--- a/web/src/game/motion.test.ts
+++ b/web/src/game/motion.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { motionManager, MOTION_SPEEDS, type MotionSpeed } from './motion'
+
+// The MotionManager is a module singleton constructed at import time. These
+// tests exercise its runtime behaviour (set/cycle/persist/notify/scale), which
+// is what the UI depends on.
+describe('MotionManager', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    // Reset to a known baseline before each test.
+    motionManager.setSpeed('normal')
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('exposes the four speeds in cycle order', () => {
+    expect(MOTION_SPEEDS).toEqual(['off', 'slow', 'normal', 'fast'])
+  })
+
+  it('setSpeed updates the current speed and persists it', () => {
+    motionManager.setSpeed('fast')
+    expect(motionManager.getSpeed()).toBe('fast')
+    expect(localStorage.getItem('seven_spade_motion')).toBe('fast')
+  })
+
+  it('durationScale maps each speed to its multiplier', () => {
+    const expected: Record<MotionSpeed, number> = { off: 0, slow: 1.6, normal: 1, fast: 0.6 }
+    for (const speed of MOTION_SPEEDS) {
+      motionManager.setSpeed(speed)
+      expect(motionManager.durationScale()).toBe(expected[speed])
+    }
+  })
+
+  it('isEnabled is false only when off', () => {
+    motionManager.setSpeed('off')
+    expect(motionManager.isEnabled()).toBe(false)
+    motionManager.setSpeed('slow')
+    expect(motionManager.isEnabled()).toBe(true)
+  })
+
+  it('cycle advances off -> slow -> normal -> fast -> off', () => {
+    motionManager.setSpeed('off')
+    motionManager.cycle()
+    expect(motionManager.getSpeed()).toBe('slow')
+    motionManager.cycle()
+    expect(motionManager.getSpeed()).toBe('normal')
+    motionManager.cycle()
+    expect(motionManager.getSpeed()).toBe('fast')
+    motionManager.cycle()
+    expect(motionManager.getSpeed()).toBe('off')
+  })
+
+  it('publishes the --anim-scale CSS variable and data-motion attribute', () => {
+    motionManager.setSpeed('slow')
+    expect(document.documentElement.style.getPropertyValue('--anim-scale')).toBe('1.6')
+    expect(document.documentElement.dataset.motion).toBe('slow')
+    motionManager.setSpeed('off')
+    expect(document.documentElement.style.getPropertyValue('--anim-scale')).toBe('0')
+    expect(document.documentElement.dataset.motion).toBe('off')
+  })
+
+  it('notifies subscribers on change and stops after unsubscribe', () => {
+    const seen: MotionSpeed[] = []
+    const unsubscribe = motionManager.subscribe((speed) => seen.push(speed))
+    motionManager.setSpeed('fast')
+    motionManager.setSpeed('off')
+    unsubscribe()
+    motionManager.setSpeed('normal')
+    expect(seen).toEqual(['fast', 'off'])
+  })
+})

--- a/web/src/game/motion.ts
+++ b/web/src/game/motion.ts
@@ -1,0 +1,147 @@
+// Motion preference manager for card-play animations.
+//
+// Mirrors the AudioManager pattern (game/sound.ts): a module singleton that
+// persists a preference to localStorage and exposes a subscribe() pub-sub so
+// React can mirror it into state. The preference is one of four speeds; "off"
+// disables all gameplay animations. The default honours the OS-level
+// `prefers-reduced-motion` setting — when the user asked the system to reduce
+// motion, we default to "off" — but an explicit choice always wins and is
+// remembered.
+//
+// Animations themselves are pure CSS (keyframes in index.css). This manager
+// only owns the *duration scale*, published as the `--anim-scale` CSS variable
+// on <html>, which every keyframe/transition multiplies into its duration.
+// "off" collapses the scale to 0 so animations resolve instantly (no motion).
+
+export type MotionSpeed = 'off' | 'slow' | 'normal' | 'fast'
+
+export const MOTION_SPEEDS: MotionSpeed[] = ['off', 'slow', 'normal', 'fast']
+
+const MOTION_KEY = 'seven_spade_motion'
+
+// Duration multiplier applied to every animation for each speed. "off" is 0 so
+// the CSS resolves to a 0s duration (instant, effectively disabled).
+const SCALE: Record<MotionSpeed, number> = {
+  off: 0,
+  slow: 1.6,
+  normal: 1,
+  fast: 0.6,
+}
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || !window.matchMedia) return false
+  try {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  } catch {
+    return false
+  }
+}
+
+function isMotionSpeed(value: unknown): value is MotionSpeed {
+  return value === 'off' || value === 'slow' || value === 'normal' || value === 'fast'
+}
+
+// readSpeed resolves the initial preference: an explicit stored choice wins;
+// otherwise the OS reduced-motion setting decides (off when set, normal else).
+function readSpeed(): MotionSpeed {
+  try {
+    const stored = window.localStorage.getItem(MOTION_KEY)
+    if (isMotionSpeed(stored)) return stored
+  } catch {
+    // Ignore storage failures (private mode, SSR); fall through to OS default.
+  }
+  return prefersReducedMotion() ? 'off' : 'normal'
+}
+
+class MotionManager {
+  private speed: MotionSpeed = readSpeed()
+  private hasExplicitChoice = false
+  private readonly listeners = new Set<(speed: MotionSpeed) => void>()
+
+  constructor() {
+    // Record whether the initial value came from an explicit stored choice, so
+    // a later OS reduced-motion change only overrides an *un-chosen* default.
+    try {
+      this.hasExplicitChoice = isMotionSpeed(window.localStorage.getItem(MOTION_KEY))
+    } catch {
+      this.hasExplicitChoice = false
+    }
+    this.applyToDocument()
+    this.watchReducedMotion()
+  }
+
+  getSpeed(): MotionSpeed {
+    return this.speed
+  }
+
+  // enabled is true unless the user (or the OS default) turned animations off.
+  isEnabled(): boolean {
+    return this.speed !== 'off'
+  }
+
+  // durationScale is the multiplier the CSS uses; 0 when off.
+  durationScale(): number {
+    return SCALE[this.speed]
+  }
+
+  setSpeed(speed: MotionSpeed): void {
+    this.speed = speed
+    this.hasExplicitChoice = true
+    try {
+      window.localStorage.setItem(MOTION_KEY, speed)
+    } catch {
+      // In-memory state still works without persistence.
+    }
+    this.applyToDocument()
+    for (const listener of this.listeners) listener(speed)
+  }
+
+  // cycle advances to the next speed (Off -> Slow -> Normal -> Fast -> Off),
+  // used by the single-button header control.
+  cycle(): void {
+    const index = MOTION_SPEEDS.indexOf(this.speed)
+    const next = MOTION_SPEEDS[(index + 1) % MOTION_SPEEDS.length]
+    this.setSpeed(next)
+  }
+
+  subscribe(listener: (speed: MotionSpeed) => void): () => void {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  // applyToDocument publishes the scale as a CSS variable + a data attribute so
+  // stylesheets can both compute durations and target [data-motion="off"].
+  private applyToDocument(): void {
+    if (typeof document === 'undefined') return
+    const root = document.documentElement
+    root.style.setProperty('--anim-scale', String(SCALE[this.speed]))
+    root.dataset.motion = this.speed
+  }
+
+  // watchReducedMotion keeps an un-chosen default in sync with the OS setting:
+  // if the player never picked a speed and toggles reduced-motion at the OS
+  // level, flip between off and normal to match.
+  private watchReducedMotion(): void {
+    if (typeof window === 'undefined' || !window.matchMedia) return
+    let query: MediaQueryList
+    try {
+      query = window.matchMedia('(prefers-reduced-motion: reduce)')
+    } catch {
+      return
+    }
+    const handler = (event: MediaQueryListEvent) => {
+      if (this.hasExplicitChoice) return
+      this.speed = event.matches ? 'off' : 'normal'
+      this.applyToDocument()
+      for (const listener of this.listeners) listener(this.speed)
+    }
+    if (typeof query.addEventListener === 'function') {
+      query.addEventListener('change', handler)
+    }
+  }
+}
+
+// Module singleton so every consumer shares the same preference + CSS var.
+export const motionManager = new MotionManager()

--- a/web/src/hooks/useMotion.ts
+++ b/web/src/hooks/useMotion.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useState } from 'react'
+import { motionManager, type MotionSpeed } from '../game/motion'
+
+export type UseMotionReturn = {
+  speed: MotionSpeed
+  enabled: boolean
+  scale: number
+  setSpeed: (speed: MotionSpeed) => void
+  cycle: () => void
+}
+
+// useMotion wraps the MotionManager singleton, tracking the speed as React
+// state so toggle UI re-renders. The manager owns persistence (localStorage),
+// the prefers-reduced-motion default, and publishing the --anim-scale CSS var.
+export function useMotion(): UseMotionReturn {
+  const [speed, setSpeedState] = useState<MotionSpeed>(() => motionManager.getSpeed())
+
+  useEffect(() => motionManager.subscribe(setSpeedState), [])
+
+  const setSpeed = useCallback((next: MotionSpeed) => {
+    motionManager.setSpeed(next)
+  }, [])
+
+  const cycle = useCallback(() => {
+    motionManager.cycle()
+  }, [])
+
+  return {
+    speed,
+    enabled: speed !== 'off',
+    scale: motionManager.durationScale(),
+    setSpeed,
+    cycle,
+  }
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -85,6 +85,154 @@ body {
   }
 }
 
+/* ---------------------------------------------------------------------------
+ * Card-play animations (issue #48).
+ *
+ * All gameplay animations are pure CSS using only transform/opacity (GPU
+ * friendly). Durations multiply a base by --anim-scale, the variable published
+ * by MotionManager (game/motion.ts): normal = 1, slow = 1.6, fast = 0.6, and
+ * off = 0 (which makes the animation resolve instantly — effectively
+ * disabled). --anim-scale falls back to 1 if the manager hasn't run yet.
+ * ------------------------------------------------------------------------- */
+
+:root {
+  --anim-scale: 1;
+}
+
+/* A card landing on the board: rises and scales into place while fading in. */
+@keyframes card-land {
+  0% {
+    opacity: 0;
+    transform: translateY(14px) scale(0.82);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* Face-down penalty: a quick 3D flip onto its back. */
+@keyframes card-flip-down {
+  0% {
+    transform: rotateY(0deg) scale(1);
+  }
+
+  50% {
+    transform: rotateY(90deg) scale(0.96);
+  }
+
+  100% {
+    transform: rotateY(0deg) scale(1);
+  }
+}
+
+/* Ace close: a one-shot gold halo pulse around the closing Ace. */
+@keyframes ace-glow {
+  0% {
+    box-shadow: 0 0 0 0 rgb(245 200 66 / 0%);
+  }
+
+  35% {
+    box-shadow: 0 0 12px 4px rgb(245 200 66 / 70%);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 rgb(245 200 66 / 0%);
+  }
+}
+
+/* Opponent play: fade + slide in (we never see their hand, so the card just
+ * appears on the board). */
+@keyframes opponent-card-in {
+  0% {
+    opacity: 0;
+    transform: translateY(-10px) scale(0.9);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* A card leaving the hand: slide up and fade before unmount. */
+@keyframes card-leave {
+  0% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translateY(-28px) scale(0.85);
+  }
+}
+
+/* Game-over reveal: a penalty card flips face-up. */
+@keyframes card-reveal {
+  0% {
+    opacity: 0;
+    transform: rotateY(90deg);
+  }
+
+  100% {
+    opacity: 1;
+    transform: rotateY(0deg);
+  }
+}
+
+.anim-card-land {
+  animation: card-land calc(0.38s * var(--anim-scale)) var(--ease-spade-spring) both;
+}
+
+.anim-card-flip-down {
+  animation: card-flip-down calc(0.4s * var(--anim-scale)) ease-in-out both;
+  transform-style: preserve-3d;
+}
+
+.anim-ace-glow {
+  animation: ace-glow calc(0.7s * var(--anim-scale)) ease-out both;
+  border-radius: 10px;
+}
+
+.anim-opponent-card-in {
+  animation: opponent-card-in calc(0.42s * var(--anim-scale)) ease-out both;
+}
+
+.anim-card-leave {
+  animation: card-leave calc(0.22s * var(--anim-scale)) ease-in both;
+}
+
+.anim-card-reveal {
+  animation: card-reveal calc(0.45s * var(--anim-scale)) var(--ease-spade-spring) both;
+  transform-style: preserve-3d;
+}
+
+/* Hard stop: when motion is off, neutralise every gameplay animation so the
+ * board snaps to its committed state with no transition. */
+[data-motion='off'] .anim-card-land,
+[data-motion='off'] .anim-card-flip-down,
+[data-motion='off'] .anim-ace-glow,
+[data-motion='off'] .anim-opponent-card-in,
+[data-motion='off'] .anim-card-leave,
+[data-motion='off'] .anim-card-reveal {
+  animation: none;
+}
+
+/* Belt-and-braces: if the manager hasn't initialised yet, still honour the OS
+ * reduced-motion setting. */
+@media (prefers-reduced-motion: reduce) {
+  :root:not([data-motion='slow']):not([data-motion='normal']):not([data-motion='fast']) .anim-card-land,
+  :root:not([data-motion='slow']):not([data-motion='normal']):not([data-motion='fast']) .anim-card-flip-down,
+  :root:not([data-motion='slow']):not([data-motion='normal']):not([data-motion='fast']) .anim-ace-glow,
+  :root:not([data-motion='slow']):not([data-motion='normal']):not([data-motion='fast']) .anim-opponent-card-in,
+  :root:not([data-motion='slow']):not([data-motion='normal']):not([data-motion='fast']) .anim-card-leave,
+  :root:not([data-motion='slow']):not([data-motion='normal']):not([data-motion='fast']) .anim-card-reveal {
+    animation: none;
+  }
+}
+
 .font-mono {
   font-family: 'DM Mono', 'Fira Mono', monospace;
 }

--- a/web/src/pages/GamePage.tsx
+++ b/web/src/pages/GamePage.tsx
@@ -340,7 +340,16 @@ function OpponentCard({ player, isCurrentTurn, emote }: { player: Player; isCurr
       <Avatar avatarUrl={player.avatarUrl} initials={player.initials} tone={player.tone} sizeClass="size-9" className="text-xs" />
       <span className="max-w-[80px] truncate text-xs font-medium text-spade-cream">{player.name}</span>
       <div className="flex items-center gap-2 text-[10px] text-spade-gray-3">
-        <span title="Cards in hand">🃏 {player.cardsLeft}</span>
+        {/* Keying on the count remounts this badge whenever the opponent's hand
+            changes, replaying the CSS pulse once — a small acknowledgement of a
+            play we never see (their hand is hidden). Gated by motion preference. */}
+        <span
+          key={`cards-${player.cardsLeft}`}
+          className="anim-opponent-card-in"
+          title="Cards in hand"
+        >
+          🃏 {player.cardsLeft}
+        </span>
         <span title="Face-down cards">⬇ {player.faceDownCount}</span>
       </div>
       {player.disconnected ? <span className="text-[9px] text-red-400">Disconnected</span> : null}
@@ -400,7 +409,7 @@ function PlayerHand({
 
           return (
             <div
-              key={`${card.rank}-${card.suit}-${index}`}
+              key={`${card.rank}-${card.suit}`}
               className="-ml-5 first:ml-0 transition-transform duration-150"
               style={{
                 transform: `rotate(${rotation}deg) translateY(${translateY}px)`,
@@ -412,6 +421,7 @@ function PlayerHand({
                 interactive={cardsInteractive}
                 onClick={clickable ? () => handleClick(card) : undefined}
                 ariaLabel={faceDownMode ? `Select ${card.rank} of ${card.suit} for face down` : undefined}
+                animationClassName={faceDownMode && card.selected ? 'anim-card-flip-down' : ''}
               />
             </div>
           )
@@ -596,9 +606,11 @@ function RevealedPenaltyCardGroup({ result }: { result: GameResult }) {
 
       <div className="flex flex-wrap gap-2">
         {result.faceDownCards.length === 0 ? <span className="text-sm text-spade-gray-2">No penalty cards</span> : null}
-        {result.faceDownCards.map((card) => (
+        {result.faceDownCards.map((card, index) => (
           <div key={`${result.player}-${card.rank}-${card.suit}`} className="flex items-center gap-2 rounded-spade-sm border border-spade-cream/10 bg-spade-bg/70 px-2 py-1">
-            <CardFace card={card} size="sm" interactive={false} ariaLabel={`${card.rank} of ${card.suit}`} />
+            <div className="anim-card-reveal" style={{ animationDelay: `calc(${index * 0.06}s * var(--anim-scale))` }}>
+              <CardFace card={card} size="sm" interactive={false} ariaLabel={`${card.rank} of ${card.suit}`} />
+            </div>
             <span className="grid gap-1">
               <span className="text-xs text-spade-cream">{card.rank} of {card.suit}</span>
               <span className="font-mono text-xs text-spade-gold-light">+{card.points}</span>


### PR DESCRIPTION
Closes #48.

## Summary

Adds CSS-driven gameplay animations with a user-controllable speed, built
on the repo's existing keyframe convention — no animation library added.

**Animations (web)**
- **Card play** — a card slides + scales + fades onto its board slot.
- **Opponent play** — same board landing (we never see their hand, so the
  card just animates onto the board); their card-count badge also pulses.
- **Ace close** — a gold glow pulses at the closing end of the suit.
- **Face-down penalty** — the selected hand card flips (3D rotateY).
- **Game over reveal** — each penalty card flips face-up, staggered.

**Animation system**
- New `MotionManager` singleton (`web/src/game/motion.ts`) mirroring the
  sound manager: persists an `off` / `slow` / `normal` / `fast` preference
  to `localStorage`, **defaults to off when the OS `prefers-reduced-motion`
  is set**, watches the media query, and publishes a `--anim-scale` CSS var
  + `data-motion` attribute on `<html>`.
- Every keyframe multiplies its base duration by `--anim-scale`, so `off`
  collapses to `0s` (no motion) and the speeds scale (slow 1.6x, fast 0.6x).
- `useMotion` hook + a header speed-cycle button next to the sound toggle.
- Animations use **transform/opacity only** (GPU friendly) and are purely
  visual — state updates immediately; a board `CardFace` only mounts when
  its slot fills, so the CSS `both` animation plays exactly once and never
  blocks gameplay or restarts on re-render.

## Scope deltas (as agreed)
- **Mobile** (Reanimated + expo-haptics) deferred to a follow-up slice.
- **Flight** is a slide/scale onto the board, not a measured hand-to-board
  FLIP; **deal fan-out** deferred.

## What was tested
- `web`: `npm test` — 169 passed incl. **7 new `game/motion.test.ts`**
  tests (set/cycle/scale/persist/notify/CSS-var). The 1 failure is the
  pre-existing `BadgeGrid` test, unchanged from `main`.
- `npm run build` and `npm run lint` clean.
- Browser-verified: header control cycles normal→fast→off→slow, updates
  `--anim-scale` (1 → 0.6 → 0 → 1.6) and `data-motion`, persists to
  localStorage; all six keyframes load.

## Manual sanity check
1. Play a card → it slides onto the board; close a suit with an Ace → gold
   glow; hit a face-down turn → the picked card flips.
2. Watch an opponent move → their count badge pulses.
3. Finish a game → penalty cards flip face-up in sequence.
4. Cycle the header ⏯ control through Off/Slow/Normal/Fast and toggle the
   OS reduce-motion setting to confirm the default respects it.

## Roadmap
Flipped `docs/roadmap.md` line 154 to ✅.