### PR TITLE
feat: 7 new achievements + shared-win rework

### DIFF
--- a/services/api/internal/database/migrations/025_new_achievements.sql
+++ b/services/api/internal/database/migrations/025_new_achievements.sql
@@ -1,0 +1,53 @@
+-- New achievements and updated shared-win rule.
+-- Good Company is re-scoped to 2-player shared wins only (shared_win_count eq 2);
+-- Triumvirate and United Front cover 3- and 4-player ties.
+-- Penalty thresholds, clean sweeps, no-Ace games, and speed runs round out the
+-- per-game badge set.
+
+-- ============================================================================
+-- Update existing Good Company rule: shared_win_count eq 2 (was shared_win)
+-- ============================================================================
+DELETE FROM achievement_rules WHERE achievement_id = 'shared_win';
+
+INSERT INTO achievement_rules (achievement_id, metric, operator, value)
+VALUES ('shared_win', 'shared_win_count', 'eq', '2');
+
+-- ============================================================================
+-- New catalog entries
+-- ============================================================================
+INSERT INTO achievements (id, name, description, icon, display_order, enabled)
+VALUES
+    ('high_penalty',  'Chumbo',        'Finish a game with 100+ penalty',          '💣', 200, TRUE),
+    ('penalty_80',    'Ouch',          'Finish a game with 80+ penalty',           '🤕', 210, TRUE),
+    ('all_clean',     'Clean Sweep',   'All players finish with 0 penalty',        '🧹', 220, TRUE),
+    ('no_ace_close',  'Old School',    'No Ace closes a suit all game',            '♠',  230, TRUE),
+    ('shared_win_3',  'Triumvirate',   'Share a win with two other players',       '🤝', 240, TRUE),
+    ('shared_win_4',  'United Front',  'All registered players share the win',     '🏛',  250, TRUE),
+    ('short_game',    'Speed Demon',   'Finish a game in under 2 minutes',         '⚡', 260, TRUE)
+
+ON CONFLICT (id) DO UPDATE SET
+    name        = EXCLUDED.name,
+    description = EXCLUDED.description,
+    icon        = EXCLUDED.icon,
+    display_order = EXCLUDED.display_order,
+    enabled     = EXCLUDED.enabled,
+    updated_at  = NOW();
+
+-- ============================================================================
+-- Rules for each new achievement
+-- ============================================================================
+DELETE FROM achievement_rules
+WHERE achievement_id IN (
+    'high_penalty', 'penalty_80', 'all_clean', 'no_ace_close',
+    'shared_win_3', 'shared_win_4', 'short_game'
+);
+
+INSERT INTO achievement_rules (achievement_id, metric, operator, value)
+VALUES
+    ('high_penalty',  'penalty',                'gte',  '100'),
+    ('penalty_80',    'penalty',                'gte',  '80'),
+    ('all_clean',     'all_zero_penalty',       'eq',   'true'),
+    ('no_ace_close',  'ace_closed',             'eq',   'false'),
+    ('shared_win_3',  'shared_win_count',       'eq',   '3'),
+    ('shared_win_4',  'shared_win_count',       'eq',   '4'),
+    ('short_game',    'game_duration_seconds',  'lte',  '120');

--- a/services/api/internal/repository/achievements.go
+++ b/services/api/internal/repository/achievements.go
@@ -21,15 +21,23 @@ const (
 	AchievementPerfectRound = "perfect_round"
 	AchievementSharedWin    = "shared_win"
 
-	AchievementWins50           = "wins_50"
-	AchievementWins100          = "wins_100"
-	AchievementStreak10         = "streak_10"
-	AchievementStreak15         = "streak_15"
-	AchievementFirsts50         = "firsts_50"
-	AchievementFirsts100        = "firsts_100"
-	AchievementZeroPenalty10    = "zero_penalty_games_10"
-	AchievementGames200         = "games_200"
-	AchievementHumanOnly25      = "human_only_25"
+	AchievementWins50        = "wins_50"
+	AchievementWins100       = "wins_100"
+	AchievementStreak10      = "streak_10"
+	AchievementStreak15      = "streak_15"
+	AchievementFirsts50      = "firsts_50"
+	AchievementFirsts100     = "firsts_100"
+	AchievementZeroPenalty10 = "zero_penalty_games_10"
+	AchievementGames200      = "games_200"
+	AchievementHumanOnly25   = "human_only_25"
+
+	AchievementHighPenalty = "high_penalty"
+	AchievementPenalty80   = "penalty_80"
+	AchievementAllClean    = "all_clean"
+	AchievementNoAceClose  = "no_ace_close"
+	AchievementSharedWin3  = "shared_win_3"
+	AchievementSharedWin4  = "shared_win_4"
+	AchievementShortGame   = "short_game"
 )
 
 // Achievement is the display catalog row returned to clients.
@@ -56,18 +64,22 @@ type achievementRule struct {
 // achievementContext carries everything the evaluator needs about one player's
 // just-saved game and updated counters, all available inside SaveGame's tx.
 type achievementContext struct {
-	IsWinner      bool
-	SharedWin     bool // winner tied with at least one other player
-	Penalty       int
-	GamesPlayed   int
-	Wins          int
-	CurrentStreak int
+	IsWinner       bool
+	SharedWinCount int // number of registered winners (0 if this player did not win)
+	Penalty        int
+	GamesPlayed    int
+	Wins           int
+	CurrentStreak  int
 	// Post-update snapshot fields from UpsertUserStats.
 	CurrentTop2Streak int
 	// Accumulated counters from UpsertUserStats RETURNING.
 	FirstPlaceCount  int
 	ZeroPenaltyGames int
 	HumanOnlyGames   int
+	// Per-game aggregate fields computed before the player loop.
+	AllZeroPenalty      bool
+	AceClosed           bool
+	GameDurationSeconds int
 }
 
 // EvaluateAchievementIDs returns every enabled achievement whose DB-configured
@@ -129,8 +141,8 @@ func ruleMatches(ctx achievementContext, rule achievementRule) (bool, error) {
 	switch rule.Metric {
 	case "is_winner":
 		return compareBool(ctx.IsWinner, rule.Operator, rule.Value)
-	case "shared_win":
-		return compareBool(ctx.SharedWin, rule.Operator, rule.Value)
+	case "shared_win_count":
+		return compareInt(ctx.SharedWinCount, rule.Operator, rule.Value)
 	case "penalty":
 		return compareInt(ctx.Penalty, rule.Operator, rule.Value)
 	case "games_played":
@@ -147,6 +159,12 @@ func ruleMatches(ctx achievementContext, rule achievementRule) (bool, error) {
 		return compareInt(ctx.ZeroPenaltyGames, rule.Operator, rule.Value)
 	case "human_only_games":
 		return compareInt(ctx.HumanOnlyGames, rule.Operator, rule.Value)
+	case "all_zero_penalty":
+		return compareBool(ctx.AllZeroPenalty, rule.Operator, rule.Value)
+	case "ace_closed":
+		return compareBool(ctx.AceClosed, rule.Operator, rule.Value)
+	case "game_duration_seconds":
+		return compareInt(ctx.GameDurationSeconds, rule.Operator, rule.Value)
 	default:
 		return false, fmt.Errorf("unknown achievement metric %q for %s", rule.Metric, rule.AchievementID)
 	}

--- a/services/api/internal/repository/achievements_test.go
+++ b/services/api/internal/repository/achievements_test.go
@@ -59,17 +59,30 @@ func TestEvaluateAchievementIDsNewMetrics(t *testing.T) {
 			AddRow(AchievementFirsts100, "first_place_count", "gte", "100").
 			AddRow(AchievementZeroPenalty10, "zero_penalty_games", "gte", "10").
 			AddRow(AchievementGames200, "games_played", "gte", "200").
-			AddRow(AchievementHumanOnly25, "human_only_games", "gte", "25"))
+			AddRow(AchievementHumanOnly25, "human_only_games", "gte", "25").
+			AddRow(AchievementHighPenalty, "penalty", "gte", "100").
+			AddRow(AchievementPenalty80, "penalty", "gte", "80").
+			AddRow(AchievementAllClean, "all_zero_penalty", "eq", "true").
+			AddRow(AchievementNoAceClose, "ace_closed", "eq", "false").
+			AddRow(AchievementShortGame, "game_duration_seconds", "lte", "120").
+			AddRow(AchievementSharedWin3, "shared_win_count", "eq", "3").
+			AddRow(AchievementSharedWin4, "shared_win_count", "eq", "4"))
 	mock.ExpectRollback()
 
 	tx, _ := db.Begin()
 	got, err := EvaluateAchievementIDs(tx, achievementContext{
-		GamesPlayed:      200,
-		Wins:             100,
-		CurrentStreak:    15,
-		FirstPlaceCount:  100,
-		ZeroPenaltyGames: 12,
-		HumanOnlyGames:   30,
+		IsWinner:            true,
+		SharedWinCount:      3,
+		Penalty:             100,
+		GamesPlayed:         200,
+		Wins:                100,
+		CurrentStreak:       15,
+		FirstPlaceCount:     100,
+		ZeroPenaltyGames:    12,
+		HumanOnlyGames:      30,
+		AllZeroPenalty:      true,
+		AceClosed:           false,
+		GameDurationSeconds: 90,
 	})
 	if err != nil {
 		t.Fatalf("EvaluateAchievementIDs: %v", err)
@@ -83,6 +96,12 @@ func TestEvaluateAchievementIDsNewMetrics(t *testing.T) {
 		AchievementZeroPenalty10,
 		AchievementGames200,
 		AchievementHumanOnly25,
+		AchievementHighPenalty,
+		AchievementPenalty80,
+		AchievementAllClean,
+		AchievementNoAceClose,
+		AchievementShortGame,
+		AchievementSharedWin3,
 	}
 	if !sameSet(got, want) {
 		t.Fatalf("ids = %v, want %v", got, want)
@@ -100,13 +119,14 @@ func TestEvaluateAchievementIDsSupportsBooleanAndAndRules(t *testing.T) {
 	mock.ExpectQuery("FROM achievements a").
 		WillReturnRows(sqlmock.NewRows([]string{"id", "metric", "operator", "value"}).
 			AddRow(AchievementFirstWin, "is_winner", "eq", "true").
-			AddRow(AchievementSharedWin, "shared_win", "eq", "true").
+			AddRow(AchievementSharedWin, "shared_win_count", "eq", "2").
+			AddRow(AchievementZeroPenalty10, "zero_penalty_games", "gte", "10").
 			AddRow("winner_zero", "is_winner", "eq", "true").
 			AddRow("winner_zero", "penalty", "eq", "0"))
 	mock.ExpectRollback()
 
 	tx, _ := db.Begin()
-	got, err := EvaluateAchievementIDs(tx, achievementContext{IsWinner: true, SharedWin: true, Penalty: 0})
+	got, err := EvaluateAchievementIDs(tx, achievementContext{IsWinner: true, SharedWinCount: 2, Penalty: 0})
 	if err != nil {
 		t.Fatalf("EvaluateAchievementIDs: %v", err)
 	}

--- a/services/api/internal/repository/game.go
+++ b/services/api/internal/repository/game.go
@@ -201,7 +201,25 @@ func SaveGame(db *sql.DB, result GameResult) (GameSaveResult, error) {
 			hasBot = true
 		}
 	}
-	sharedWin := registeredWinners > 1
+	sharedWinCount := registeredWinners
+
+	allZeroPenalty := true
+	aceClosed := false
+	for _, player := range result.Players {
+		if !player.IsBot && player.PenaltyPoints > 0 {
+			allZeroPenalty = false
+		}
+	}
+	for _, move := range result.Moves {
+		if move.Type == "ace_close" {
+			aceClosed = true
+			break
+		}
+	}
+	gameDurationSeconds := int(result.FinishedAt.Sub(result.StartedAt).Seconds())
+	if gameDurationSeconds < 0 {
+		gameDurationSeconds = 0
+	}
 
 	pen := closeGamePenalties(result.Players)
 
@@ -260,17 +278,24 @@ func SaveGame(db *sql.DB, result GameResult) (GameSaveResult, error) {
 				}
 			}
 			eloPlayers = append(eloPlayers, EloPlayer{UserID: *userID, Rank: player.Rank})
+			sWinCount := 0
+			if player.IsWinner {
+				sWinCount = sharedWinCount
+			}
 			ids, err := EvaluateAchievementIDs(tx, achievementContext{
-				IsWinner:          player.IsWinner,
-				SharedWin:         player.IsWinner && sharedWin,
-				Penalty:           player.PenaltyPoints,
-				GamesPlayed:       snap.GamesPlayed,
-				Wins:              snap.Wins,
-				CurrentStreak:     snap.CurrentStreak,
-				CurrentTop2Streak: snap.CurrentTop2Streak,
-				FirstPlaceCount:   snap.FirstPlaceCount,
-				ZeroPenaltyGames:  snap.ZeroPenaltyGames,
-				HumanOnlyGames:    snap.HumanOnlyGames,
+				IsWinner:            player.IsWinner,
+				SharedWinCount:      sWinCount,
+				Penalty:             player.PenaltyPoints,
+				GamesPlayed:         snap.GamesPlayed,
+				Wins:                snap.Wins,
+				CurrentStreak:       snap.CurrentStreak,
+				CurrentTop2Streak:   snap.CurrentTop2Streak,
+				FirstPlaceCount:     snap.FirstPlaceCount,
+				ZeroPenaltyGames:    snap.ZeroPenaltyGames,
+				HumanOnlyGames:      snap.HumanOnlyGames,
+				AllZeroPenalty:      allZeroPenalty,
+				AceClosed:           aceClosed,
+				GameDurationSeconds: gameDurationSeconds,
 			})
 			if err != nil {
 				return empty, err


### PR DESCRIPTION
- penalty_80 & high_penalty: shame badges for heavy penalty rounds
- all_clean (Clean Sweep): every human player finishes with 0 penalty
- no_ace_close (Old School): no Ace closes a suit all game
- short_game (Speed Demon): finish under 2 minutes
- shared_win_3 (Triumvirate) & shared_win_4 (United Front): 3- and 4-player shared wins
- Good Company re-scoped to 2-player shared wins only (shared_win bool → shared_win_count int metric)

New per-game aggregate metrics on achievementContext: all_zero_penalty, ace_closed, game_duration_seconds, shared_win_count (replaces SharedWin bool).
All computed from GameResult data already flowing into SaveGame — zero WS changes.

Migration 025_new_achievements.sql.