### PR TITLE
feat(game): let players view their own face-down penalty pile

### DIFF
--- a/services/ws/server.go
+++ b/services/ws/server.go
@@ -2066,6 +2066,11 @@ func (room *room) stateMessageFor(playerIndex int) map[string]any {
 		yourHand = append(yourHand, cardPayload(card, validCards[card]))
 	}
 
+	yourFaceDown := make([]map[string]any, 0, len(room.state.FaceDown[playerIndex]))
+	for _, card := range room.state.FaceDown[playerIndex] {
+		yourFaceDown = append(yourFaceDown, cardPayload(card, false))
+	}
+
 	opponents := make([]map[string]any, 0, game.PlayerCount-1)
 	for i := 1; i < len(room.players); i++ {
 		idx := (playerIndex + i) % len(room.players)
@@ -2081,20 +2086,22 @@ func (room *room) stateMessageFor(playerIndex int) map[string]any {
 	}
 
 	return map[string]any{
-		"type":               messageTypeStateUpdate,
-		"status":             "in_progress",
-		"board":              boardPayload(room.state),
-		"closed_suits":       closedSuits(room.state),
-		"ace_close_method":   room.state.CloseMethod,
-		"ace_close_options":  aceCloseOptions,
-		"your_hand":          yourHand,
-		"opponents":          opponents,
-		"current_turn":       room.players[room.state.CurrentPlayer].displayName,
-		"turn_ends_at":       room.turnExpiresAt.Format(time.RFC3339),
-		"turn_timer_seconds": int(room.turnTimerDuration / time.Second),
-		"bot_difficulty":     string(room.botDifficulty),
-		"practice_mode":      room.practiceMode,
-		"spectator_count":    len(room.spectators),
+		"type":                messageTypeStateUpdate,
+		"status":              "in_progress",
+		"board":               boardPayload(room.state),
+		"closed_suits":        closedSuits(room.state),
+		"ace_close_method":    room.state.CloseMethod,
+		"ace_close_options":   aceCloseOptions,
+		"your_hand":           yourHand,
+		"your_facedown":       yourFaceDown,
+		"your_facedown_count": len(yourFaceDown),
+		"opponents":           opponents,
+		"current_turn":        room.players[room.state.CurrentPlayer].displayName,
+		"turn_ends_at":        room.turnExpiresAt.Format(time.RFC3339),
+		"turn_timer_seconds":  int(room.turnTimerDuration / time.Second),
+		"bot_difficulty":      string(room.botDifficulty),
+		"practice_mode":       room.practiceMode,
+		"spectator_count":     len(room.spectators),
 	}
 }
 

--- a/web/src/hooks/useGameSocket.ts
+++ b/web/src/hooks/useGameSocket.ts
@@ -30,6 +30,8 @@ type StateUpdateMessage = {
   ace_close_method?: string
   ace_close_options?: Array<{ suit: string; can_low: boolean; can_high: boolean }>
   your_hand: Array<{ suit: string; rank: string | number; valid?: boolean }>
+  your_facedown?: Array<{ suit: string; rank: string | number }>
+  your_facedown_count?: number
   opponents?: Array<{ display_name: string; avatar_url?: string; is_bot?: boolean; hand_count: number; facedown_count: number; disconnected?: boolean }>
   current_turn: string
   turn_ends_at?: string
@@ -177,6 +179,7 @@ export type GameSocketState = {
   iAmReady: boolean
   boardRows: BoardRow[]
   hand: Card[]
+  myFaceDown: Card[]
   players: Player[]
   toasts: Toast[]
   isMyTurn: boolean
@@ -232,6 +235,7 @@ export function useGameSocket(roomId: string | undefined, token: string | null):
   const [lobby, setLobby] = useState<LobbyState | null>(null)
   const [boardRows, setBoardRows] = useState<BoardRow[]>(() => buildBoardRows({}))
   const [hand, setHand] = useState<Card[]>([])
+  const [myFaceDown, setMyFaceDown] = useState<Card[]>([])
   const [players, setPlayers] = useState<Player[]>([])
   const [toasts, setToasts] = useState<Toast[]>([])
   const [isMyTurn, setIsMyTurn] = useState(false)
@@ -379,6 +383,7 @@ export function useGameSocket(roomId: string | undefined, token: string | null):
       handleMessage(event.data, myDisplayName, myAvatarUrl, {
         setBoardRows,
         setHand,
+        setMyFaceDown,
         setPlayers,
         pushToast,
         setIsMyTurn,
@@ -499,6 +504,7 @@ export function useGameSocket(roomId: string | undefined, token: string | null):
     iAmReady,
     boardRows,
     hand,
+    myFaceDown,
     players,
     toasts,
     isMyTurn,
@@ -533,6 +539,7 @@ export function useGameSocket(roomId: string | undefined, token: string | null):
     iAmReady,
     boardRows,
     hand,
+    myFaceDown,
     players,
     toasts,
     isMyTurn,
@@ -569,6 +576,7 @@ function handleMessage(
   setters: {
     setBoardRows: (rows: BoardRow[]) => void
     setHand: (cards: Card[]) => void
+    setMyFaceDown: (cards: Card[]) => void
     setPlayers: Dispatch<SetStateAction<Player[]>>
     pushToast: (toast: Omit<Toast, 'id'>) => void
     setIsMyTurn: (isMyTurn: boolean) => void
@@ -625,6 +633,7 @@ function handleMessage(
     setters.setPhase('playing')
     setters.setBoardRows(buildBoardRows(message.board, message.closed_suits ?? [], message.ace_close_method))
     setters.setHand(buildHand(message))
+    setters.setMyFaceDown((message.your_facedown ?? []).map(toCard))
     setters.setPlayers(buildPlayers(message, myAvatarUrl))
     const isMyTurn = myDisplayName ? message.current_turn === myDisplayName : Boolean(message.your_hand.some((card) => card.valid))
     setters.setIsMyTurn(isMyTurn)
@@ -907,7 +916,7 @@ function buildPlayers(message: StateUpdateMessage, myAvatarUrl: string | undefin
       initials: 'YU',
       avatarUrl: myAvatarUrl,
       cardsLeft: message.your_hand.length,
-      faceDownCount: 0,
+      faceDownCount: message.your_facedown_count ?? message.your_facedown?.length ?? 0,
       tone: 'green',
       active: message.your_hand.some((card) => card.valid),
     },

--- a/web/src/pages/GamePage.tsx
+++ b/web/src/pages/GamePage.tsx
@@ -212,6 +212,7 @@ export function GamePage() {
         </div>
 
         {/* Player hand */}
+        <MyFaceDownPile cards={game.myFaceDown} />
         <div className="relative">
           {game.myDisplayName ? (
             <EmoteBubble
@@ -353,6 +354,41 @@ function OpponentCard({ player, isCurrentTurn, emote }: { player: Player; isCurr
         <span title="Face-down cards">⬇ {player.faceDownCount}</span>
       </div>
       {player.disconnected ? <span className="text-[9px] text-red-400">Disconnected</span> : null}
+    </div>
+  )
+}
+
+// MyFaceDownPile renders a clickable badge showing the count of the player's
+// own face-down penalty cards. Clicking it expands a small read-only card strip
+// so the player can review what they've been forced to discard this round.
+function MyFaceDownPile({ cards }: { cards: Card[] }) {
+  const [expanded, setExpanded] = useState(false)
+  if (!cards || cards.length === 0) return null
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        aria-expanded={expanded}
+        aria-label={expanded ? 'Hide your face-down cards' : 'Show your face-down cards'}
+        className="inline-flex items-center gap-1.5 rounded-spade-pill border border-spade-cream/15 bg-spade-bg/60 px-2.5 py-0.5 text-xs text-spade-gray-2 transition hover:border-spade-gold/40 hover:text-spade-cream"
+      >
+        <span>⬇ {cards.length} face-down</span>
+        <span aria-hidden="true" className="text-[10px] text-spade-gray-3">{expanded ? '▲' : '▼'}</span>
+      </button>
+      {expanded ? (
+        <div className="flex flex-wrap items-center justify-center gap-1 rounded-spade-lg border border-spade-cream/10 bg-spade-bg/50 px-2 py-2">
+          {cards.map((card, i) => (
+            <CardFace
+              key={`${card.rank}-${card.suit}-${i}`}
+              card={card}
+              size="sm"
+              interactive={false}
+              ariaLabel={`Face-down ${card.rank} of ${card.suit}`}
+            />
+          ))}
+        </div>
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
- WS: include your_facedown + your_facedown_count in the state_update message so the player has the cards they've been forced to discard alongside the public counts of every opponent.
- Web: expose myFaceDown on GameSocketState and use the real count for the "You" seat (was hardcoded to 0). A new MyFaceDownPile component renders a toggleable pill above the hand — click to expand a small read-only strip of the penalty cards, click again to collapse.
- No new endpoints, migrations, or store changes; the new fields are additive on the existing WS payload.